### PR TITLE
Detect game version for expansion-specific config

### DIFF
--- a/TheClassicRace.toc
+++ b/TheClassicRace.toc
@@ -1,5 +1,6 @@
 ## Interface: 50503
 ## Interface-Vanilla: 11503
+## Interface-TBC: 20504
 ## Interface-Mists: 50503
 ## Title: TheClassicRace
 ## Author: Rubensayshi

--- a/TheClassicRace.toc
+++ b/TheClassicRace.toc
@@ -1,8 +1,10 @@
 ## Interface: 50503
+## Interface-Vanilla: 11503
+## Interface-Mists: 50503
 ## Title: TheClassicRace
 ## Author: Rubensayshi
 ## Version: @project-version@
-## Notes: Keep track of the top 50 players in the race to lvl60.
+## Notes: Keep track of the top 50 players in the race to max level.
 ## DefaultState: Enabled
 ## LoadOnDemand: 0
 ## SavedVariables: TheClassicRace_DB

--- a/TheClassicRace.toc
+++ b/TheClassicRace.toc
@@ -1,6 +1,6 @@
 ## Interface: 50503
 ## Interface-Vanilla: 11503
-## Interface-TBC: 20504
+## Interface-TBC: 20505
 ## Interface-Mists: 50503
 ## Title: TheClassicRace
 ## Author: Rubensayshi

--- a/src/config.lua
+++ b/src/config.lua
@@ -108,6 +108,16 @@ local TheClassicRaceConfig = {
         DEMONHUNTER = "Poo",
     },
 
+    ExpansionData = {
+        CLASSIC = { maxLevel = 60,  validClassIndexes = {1,3,4,5,7,8,9,11}, hordeOnly = {7}, allianceOnly = {2} },
+        TBC     = { maxLevel = 70,  validClassIndexes = {1,2,3,4,5,7,8,9,11} },
+        WRATH   = { maxLevel = 80,  validClassIndexes = {1,2,3,4,5,6,7,8,9,11} },
+        CATA    = { maxLevel = 85,  validClassIndexes = {1,2,3,4,5,6,7,8,9,11} },
+        MOP     = { maxLevel = 90,  validClassIndexes = {1,2,3,4,5,6,7,8,9,10,11} },
+        WOD     = { maxLevel = 100, validClassIndexes = {1,2,3,4,5,6,7,8,9,10,11} },
+        LEGION  = { maxLevel = 110, validClassIndexes = {1,2,3,4,5,6,7,8,9,10,11,12} },
+    },
+
     Network = {
         Prefix = "TCRace",
         Channel = {
@@ -137,3 +147,22 @@ local TheClassicRaceConfig = {
     },
 }
 TheClassicRace.Config = TheClassicRaceConfig
+
+function TheClassicRaceConfig:DetectExpansion()
+    local _, _, _, tocVersion = GetBuildInfo()
+    if tocVersion < 20000 then
+        return "CLASSIC"
+    elseif tocVersion < 30000 then
+        return "TBC"
+    elseif tocVersion < 40000 then
+        return "WRATH"
+    elseif tocVersion < 50000 then
+        return "CATA"
+    elseif tocVersion < 60000 then
+        return "MOP"
+    elseif tocVersion < 70000 then
+        return "WOD"
+    else
+        return "LEGION"
+    end
+end

--- a/src/config.lua
+++ b/src/config.lua
@@ -109,7 +109,7 @@ local TheClassicRaceConfig = {
     },
 
     ExpansionData = {
-        CLASSIC = { maxLevel = 60,  validClassIndexes = {1,3,4,5,7,8,9,11}, hordeOnly = {7}, allianceOnly = {2} },
+        CLASSIC = { maxLevel = 60,  validClassIndexes = {1,2,3,4,5,7,8,9,11}, hordeOnly = {7}, allianceOnly = {2} },
         TBC     = { maxLevel = 70,  validClassIndexes = {1,2,3,4,5,7,8,9,11} },
         WRATH   = { maxLevel = 80,  validClassIndexes = {1,2,3,4,5,6,7,8,9,11} },
         CATA    = { maxLevel = 85,  validClassIndexes = {1,2,3,4,5,6,7,8,9,11} },

--- a/src/main.lua
+++ b/src/main.lua
@@ -32,6 +32,7 @@ TheClassicRace = LibStub("AceAddon-3.0"):NewAddon("TheClassicRace", "AceConsole-
 function TheClassicRace:OnInitialize()
     self.Config = TheClassicRace.Config
     self.Colors = TheClassicRace.Colors
+    self:ApplyExpansionConfig()
     self.DB = LibStub("AceDB-3.0"):New("TheClassicRace_DB", TheClassicRace.DefaultDB, true)
 
     self:DBMigrations()
@@ -96,4 +97,36 @@ The /tcr handler, toggles the frame, unless overwritten in dev.lua with a more a
 --]]
 function TheClassicRace:slashtcr(input)
     self.StatusFrame:Show()
+end
+
+function TheClassicRace:ApplyExpansionConfig()
+    local expansion = self.Config:DetectExpansion()
+    local data = self.Config.ExpansionData[expansion]
+    if not data then return end
+
+    self.Config.MaxLevel = data.maxLevel
+    self.Config.MopClassIndexes = data.validClassIndexes
+
+    if data.hordeOnly or data.allianceOnly then
+        local faction = UnitFactionGroup("player")
+        local filtered = {}
+        local hordeOnly = {}
+        local allianceOnly = {}
+        if data.hordeOnly then
+            for _, idx in ipairs(data.hordeOnly) do hordeOnly[idx] = true end
+        end
+        if data.allianceOnly then
+            for _, idx in ipairs(data.allianceOnly) do allianceOnly[idx] = true end
+        end
+        for _, idx in ipairs(data.validClassIndexes) do
+            if faction == "Horde" and allianceOnly[idx] then
+                -- skip Alliance-only class
+            elseif faction == "Alliance" and hordeOnly[idx] then
+                -- skip Horde-only class
+            else
+                filtered[#filtered + 1] = idx
+            end
+        end
+        self.Config.MopClassIndexes = filtered
+    end
 end


### PR DESCRIPTION
## Summary

- Detects which WoW expansion is running at login using `GetBuildInfo()` TOC version ranges
- Applies expansion-specific `MaxLevel` and `MopClassIndexes` (e.g., DK not available in Classic Era, DH not in MoP)
- Filters faction-exclusive classes (Paladin alliance-only, Shaman horde-only) using `UnitFactionGroup()`

## Test plan

- [ ] Load addon in MoP Classic — verify MaxLevel = 90, all 11 classes available
- [ ] Load addon in Classic Era — verify MaxLevel = 60, DK/DH excluded
- [ ] Load addon as Alliance — verify Shaman excluded; as Horde — verify Paladin excluded
- [ ] Check `/tcr` output still shows correct leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)