### PR TITLE
Add Pioneers tab: first player to reach each level

### DIFF
--- a/TheClassicRace.toc
+++ b/TheClassicRace.toc
@@ -36,5 +36,6 @@ src\core\sync.lua
 src\core\serializer.lua
 src\core\leaderboard.lua
 src\core\updater.lua
+src\gui\pioneers-frame.lua
 src\gui\status-frame.lua
 src\gui\debug-frame.lua

--- a/src/config.lua
+++ b/src/config.lua
@@ -159,6 +159,8 @@ local TheClassicRaceConfig = {
         ScanFinished = "SCAN_FINISHED",
         RaceFinished = "RACE_FINISHED",
         RefreshGUI = "REFRESH_GUI",
+        MsgStats = "MSG_STATS",
+        BuddyUpdate = "BUDDY_UPDATE",
     },
 }
 TheClassicRace.Config = TheClassicRaceConfig

--- a/src/config.lua
+++ b/src/config.lua
@@ -142,12 +142,14 @@ local TheClassicRaceConfig = {
             GuildOffer = "GUILDOFFR",
             BuddyPing = "BPING",
             BuddyPong = "BPONG",
+            FTLSync = "FTLSYNC",
         },
     },
     Events = {
         NetworkReady = "NETWORK_READY",
         SlashWhoResult = "WHO_RESULT",
         SyncResult = "SYNC_RESULT",
+        FTLSyncResult = "FTL_SYNC_RESULT",
         BumpScan = "BUMP_SCAN",
         Ding = "DING",
         -- ScanFinished(endofrace)

--- a/src/config.lua
+++ b/src/config.lua
@@ -128,6 +128,8 @@ local TheClassicRaceConfig = {
     BuddySyncInterval = 600,   -- buddy ping every 10 minutes
     BuddyPingBatchSize = 50,   -- max buddies to ping per cycle (random sample if more)
 
+    DingPushDelay = 10,        -- seconds to batch dings before pushing to guild + buddies
+
     Network = {
         Prefix = "TCRace",
         Events = {

--- a/src/config.lua
+++ b/src/config.lua
@@ -150,7 +150,6 @@ local TheClassicRaceConfig = {
         SlashWhoResult = "WHO_RESULT",
         SyncResult = "SYNC_RESULT",
         FTLSyncResult = "FTL_SYNC_RESULT",
-        BumpScan = "BUMP_SCAN",
         Ding = "DING",
         -- ScanFinished(endofrace)
         -- should use RaceFinished though if interested in when the race is finished,

--- a/src/core/chat-notifier.lua
+++ b/src/core/chat-notifier.lua
@@ -48,22 +48,27 @@ end
 
 
 function TheClassicRaceChatNotifier:ShouldReport(playerInfo, globalRank, classRank)
-    -- ignore old dings unless rank 1
+    -- ignore stale detections (>10 min old) unless rank 1
     if playerInfo.dingedAt < self.Core:Now() - 600
             and (globalRank == nil or globalRank > 1)
             and (classRank == nil or classRank > 1) then
         return false
     end
 
-    if self.DB.profile.options.maxLevelNotify and playerInfo.level >= self.Config.MaxLevel then
-        return true
-    end
-
+    -- sliders are the primary gate
     if classRank ~= nil and classRank <= self.DB.profile.options.classTopN then
         return true
     end
 
     if globalRank ~= nil and globalRank <= self.DB.profile.options.globalTopN then
+        return true
+    end
+
+    -- maxLevelNotify only fires for rank-1 (first to max level globally or per class),
+    -- so it doesn't spam when many players are already at max level
+    if self.DB.profile.options.maxLevelNotify
+            and playerInfo.level >= self.Config.MaxLevel
+            and (globalRank == 1 or classRank == 1) then
         return true
     end
 

--- a/src/core/leaderboard.lua
+++ b/src/core/leaderboard.lua
@@ -56,15 +56,21 @@ function TheClassicRaceLeaderboard:ProcessPlayerInfo(playerInfo)
     local previousRank = nil
     for rank, player in ipairs(self.lbdb.players) do
         -- find the place where to insert the new player
-        -- sort by level desc, then by dingedAt asc (earlier ding = higher rank)
+        -- sort by level desc, then by dingedAt asc, then by name asc (tiebreaker)
+        -- the name tiebreaker ensures deterministic ordering across clients when
+        -- multiple players share the same level and second-precision timestamp
         if insertAtRank == nil then
             if playerInfo.level > player.level then
                 insertAtRank = rank
             elseif playerInfo.level == player.level
                     and playerInfo.dingedAt ~= nil
-                    and player.dingedAt ~= nil
-                    and playerInfo.dingedAt < player.dingedAt then
-                insertAtRank = rank
+                    and player.dingedAt ~= nil then
+                if playerInfo.dingedAt < player.dingedAt then
+                    insertAtRank = rank
+                elseif playerInfo.dingedAt == player.dingedAt
+                        and playerInfo.name < player.name then
+                    insertAtRank = rank
+                end
             end
         end
 

--- a/src/core/leaderboard.lua
+++ b/src/core/leaderboard.lua
@@ -17,11 +17,34 @@ setmetatable(TheClassicRaceLeaderboard, {
     end,
 })
 
+-- Canonical ranking order: level desc, then dingedAt asc (nil sorts last), then name asc.
+-- This is a strict total order so every client arrives at the exact same array,
+-- which is required for ComputeHash to agree between clients with identical data.
+local function ranksBefore(a, b)
+    if a.level ~= b.level then
+        return a.level > b.level
+    end
+    if a.dingedAt ~= b.dingedAt then
+        if a.dingedAt == nil then return false end
+        if b.dingedAt == nil then return true end
+        return a.dingedAt < b.dingedAt
+    end
+    return a.name < b.name
+end
+
+-- Re-sorts a players array into the canonical order.
+-- Used to heal DBs persisted by versions with different ordering rules.
+function TheClassicRaceLeaderboard.SortPlayers(players)
+    table.sort(players, ranksBefore)
+end
+
 -- djb2 hash over all player entries in sorted order
+-- fields are ':'-separated so different data can't concatenate to the same entry string
 function TheClassicRaceLeaderboard.ComputeHash(lbdb)
     local hash = 5381
     for _, player in ipairs(lbdb.players) do
-        local entry = player.name .. player.level .. (player.classIndex or 0) .. math.floor(player.dingedAt or 0)
+        local entry = player.name .. ":" .. player.level .. ":" .. (player.classIndex or 0)
+                .. ":" .. math.floor(player.dingedAt or 0)
         for i = 1, #entry do
             hash = ((hash * 33) + string.byte(entry, i)) % 2147483647
         end
@@ -55,23 +78,11 @@ function TheClassicRaceLeaderboard:ProcessPlayerInfo(playerInfo)
     local insertAtRank = nil
     local previousRank = nil
     for rank, player in ipairs(self.lbdb.players) do
-        -- find the place where to insert the new player
-        -- sort by level desc, then by dingedAt asc, then by name asc (tiebreaker)
-        -- the name tiebreaker ensures deterministic ordering across clients when
-        -- multiple players share the same level and second-precision timestamp
-        if insertAtRank == nil then
-            if playerInfo.level > player.level then
-                insertAtRank = rank
-            elseif playerInfo.level == player.level
-                    and playerInfo.dingedAt ~= nil
-                    and player.dingedAt ~= nil then
-                if playerInfo.dingedAt < player.dingedAt then
-                    insertAtRank = rank
-                elseif playerInfo.dingedAt == player.dingedAt
-                        and playerInfo.name < player.name then
-                    insertAtRank = rank
-                end
-            end
+        -- find the place where to insert the new player using the canonical order,
+        -- which ensures deterministic ordering across clients when multiple players
+        -- share the same level and second-precision timestamp
+        if insertAtRank == nil and ranksBefore(playerInfo, player) then
+            insertAtRank = rank
         end
 
         -- find a possibly previous entry of this player
@@ -80,15 +91,26 @@ function TheClassicRaceLeaderboard:ProcessPlayerInfo(playerInfo)
         end
     end
 
-    local isNew = previousRank == nil
-    local isDing = not isNew and playerInfo.level > self.lbdb.players[previousRank].level
-    local isDingedAtUpdate = not isNew and not isDing
-            and playerInfo.dingedAt ~= nil
-            and self.lbdb.players[previousRank].dingedAt ~= nil
-            and playerInfo.dingedAt < self.lbdb.players[previousRank].dingedAt
+    local previousPlayer = previousRank ~= nil and self.lbdb.players[previousRank] or nil
 
-    -- no change
+    local isNew = previousRank == nil
+    local isDing = not isNew and playerInfo.level > previousPlayer.level
+    -- only accept an earlier dingedAt for the level we already have the player at;
+    -- info about a lower level is stale and must not downgrade the entry, otherwise
+    -- two clients holding different (level, dingedAt) snapshots swap states forever
+    local isDingedAtUpdate = not isNew and not isDing
+            and playerInfo.level == previousPlayer.level
+            and playerInfo.dingedAt ~= nil
+            and (previousPlayer.dingedAt == nil or playerInfo.dingedAt < previousPlayer.dingedAt)
+
+    -- no change in rank; still fill in a previously unknown classIndex in place, so
+    -- clients holding the same player with and without class info converge on the
+    -- same hash instead of mismatching forever
     if not isNew and not isDing and not isDingedAtUpdate then
+        if (previousPlayer.classIndex == nil or previousPlayer.classIndex == 0)
+                and playerInfo.classIndex ~= nil and playerInfo.classIndex ~= 0 then
+            previousPlayer.classIndex = playerInfo.classIndex
+        end
         return
     end
 
@@ -102,6 +124,13 @@ function TheClassicRaceLeaderboard:ProcessPlayerInfo(playerInfo)
         return
     end
 
+    -- keep a known classIndex over an unknown incoming one
+    local classIndex = playerInfo.classIndex
+    if (classIndex == nil or classIndex == 0) and previousPlayer ~= nil
+            and previousPlayer.classIndex ~= nil and previousPlayer.classIndex ~= 0 then
+        classIndex = previousPlayer.classIndex
+    end
+
     -- remove from previous rank
     if previousRank ~= nil then
         table.remove(self.lbdb.players, previousRank)
@@ -112,7 +141,7 @@ function TheClassicRaceLeaderboard:ProcessPlayerInfo(playerInfo)
         name = playerInfo.name,
         level = playerInfo.level,
         dingedAt = playerInfo.dingedAt,
-        classIndex = playerInfo.classIndex,
+        classIndex = classIndex,
     })
 
     -- truncate when leaderboard reached max size

--- a/src/core/scanner.lua
+++ b/src/core/scanner.lua
@@ -203,7 +203,7 @@ function TheClassicRaceScanner:TriggerScan()
         query = tostring(scanMin) .. "-" .. tostring(maxLevel)
     end
 
-    TheClassicRace:PPrint("Scanning /who " .. query)
+    TheClassicRace:DebugPrint("Scanning /who " .. query)
 
     if C_FriendList then
         local ff = _G.FriendsFrame

--- a/src/core/scanner.lua
+++ b/src/core/scanner.lua
@@ -67,9 +67,6 @@ end
 function TheClassicRaceScanner:InitTicker(offset)
 end
 
-function TheClassicRaceScanner:OnBumpScan(classIndex)
-end
-
 function TheClassicRaceScanner:OnWhoListUpdate()
     -- Restore FriendsFrame so manual /who works normally again
     local ff = _G.FriendsFrame

--- a/src/core/serializer.lua
+++ b/src/core/serializer.lua
@@ -89,3 +89,81 @@ function TheClassicRaceSerializer.DeserializePlayerInfoBatch(str)
 
     return res
 end
+
+-- Serializes firstToLevel into a compact string.
+-- firstToLevel[classFilter][level] = {name, classIndex, dingedAt}
+-- Record format per entry: CF(2) LV(2) CI(2) name dingedAtDelta $
+function TheClassicRaceSerializer.SerializeFTLBatch(firstToLevel)
+    local entries = {}
+    for classFilter, levels in pairs(firstToLevel) do
+        for level, record in pairs(levels) do
+            if record.dingedAt ~= nil then
+                entries[#entries + 1] = {
+                    classFilter = classFilter,
+                    level = level,
+                    name = record.name,
+                    classIndex = record.classIndex or 0,
+                    dingedAt = record.dingedAt,
+                }
+            end
+        end
+    end
+
+    if #entries == 0 then
+        return ""
+    end
+
+    local offset = entries[1].dingedAt
+    for _, e in ipairs(entries) do
+        if e.dingedAt < offset then offset = e.dingedAt end
+    end
+    offset = math.floor(offset)
+
+    local res = string.sub("0000000000" .. offset, -10) .. "$"
+    for _, e in ipairs(entries) do
+        res = res
+            .. string.format("%02d", e.classFilter)
+            .. string.format("%02d", e.level)
+            .. string.format("%02d", e.classIndex)
+            .. e.name
+            .. (math.floor(e.dingedAt) - offset)
+            .. "$"
+    end
+
+    return res
+end
+
+-- Deserializes a firstToLevel batch string produced by SerializeFTLBatch.
+-- When duplicate (classFilter, level) entries appear, keeps the one with the earlier dingedAt.
+function TheClassicRaceSerializer.DeserializeFTLBatch(str)
+    if str == "" then
+        return {}
+    end
+
+    local offset = tonumber(string.sub(str, 1, 10))
+    str = string.sub(str, 12)
+
+    local ftldb = {}
+    for substr in string.gmatch(str, "([^$]+$)") do
+        -- format: CF(2) LV(2) CI(2) name(non-digit-non-dash) dingedAtDelta
+        local cf, lv, ci, name, delta = string.match(substr, "(%d%d)(%d%d)(%d%d)([^%d-]+)(%-?%d+)")
+        if cf and lv and ci and name and delta then
+            local classFilter = tonumber(cf)
+            local level = tonumber(lv)
+            local classIndex = tonumber(ci)
+            local dingedAt = tonumber(delta) + offset
+
+            if ftldb[classFilter] == nil then ftldb[classFilter] = {} end
+            local existing = ftldb[classFilter][level]
+            if existing == nil or dingedAt < existing.dingedAt then
+                ftldb[classFilter][level] = {
+                    name = name,
+                    classIndex = classIndex,
+                    dingedAt = dingedAt,
+                }
+            end
+        end
+    end
+
+    return ftldb
+end

--- a/src/core/serializer.lua
+++ b/src/core/serializer.lua
@@ -155,7 +155,8 @@ function TheClassicRaceSerializer.DeserializeFTLBatch(str)
 
             if ftldb[classFilter] == nil then ftldb[classFilter] = {} end
             local existing = ftldb[classFilter][level]
-            if existing == nil or dingedAt < existing.dingedAt then
+            if existing == nil or dingedAt < existing.dingedAt
+                    or (dingedAt == existing.dingedAt and name < existing.name) then
                 ftldb[classFilter][level] = {
                     name = name,
                     classIndex = classIndex,

--- a/src/core/serializer.lua
+++ b/src/core/serializer.lua
@@ -97,7 +97,10 @@ function TheClassicRaceSerializer.SerializeFTLBatch(firstToLevel)
     local entries = {}
     for classFilter, levels in pairs(firstToLevel) do
         for level, record in pairs(levels) do
-            if record.dingedAt ~= nil then
+            -- only entries that fit the 2-digit wire format; level 1 is not a ding
+            if record.dingedAt ~= nil
+                    and level >= 2 and level <= 99
+                    and classFilter >= 0 and classFilter <= 99 then
                 entries[#entries + 1] = {
                     classFilter = classFilter,
                     level = level,
@@ -153,15 +156,18 @@ function TheClassicRaceSerializer.DeserializeFTLBatch(str)
             local classIndex = tonumber(ci)
             local dingedAt = tonumber(delta) + offset
 
-            if ftldb[classFilter] == nil then ftldb[classFilter] = {} end
-            local existing = ftldb[classFilter][level]
-            if existing == nil or dingedAt < existing.dingedAt
-                    or (dingedAt == existing.dingedAt and name < existing.name) then
-                ftldb[classFilter][level] = {
-                    name = name,
-                    classIndex = classIndex,
-                    dingedAt = dingedAt,
-                }
+            -- level 1 is not a ding — ignore malformed remote entries
+            if level >= 2 then
+                if ftldb[classFilter] == nil then ftldb[classFilter] = {} end
+                local existing = ftldb[classFilter][level]
+                if existing == nil or dingedAt < existing.dingedAt
+                        or (dingedAt == existing.dingedAt and name < existing.name) then
+                    ftldb[classFilter][level] = {
+                        name = name,
+                        classIndex = classIndex,
+                        dingedAt = dingedAt,
+                    }
+                end
             end
         end
     end

--- a/src/core/sync.lua
+++ b/src/core/sync.lua
@@ -545,16 +545,26 @@ function TheClassicRaceSync:OnNetBuddyPong(payload, sender)
 end
 
 -- Whispers our complete firstToLevel dataset to the target player.
+-- Payload is a table {ftlBatchString, realmOpenedAt} so both are synced together.
 function TheClassicRaceSync:SyncFTL(syncTo)
     local ftlstr = TheClassicRace.Serializer.SerializeFTLBatch(self.DB.factionrealm.firstToLevel or {})
-    self.Network:SendObject(self.Config.Network.Events.FTLSync, ftlstr, "WHISPER", syncTo)
+    local payload = {ftlstr, self.DB.factionrealm.realmOpenedAt}
+    self.Network:SendObject(self.Config.Network.Events.FTLSync, payload, "WHISPER", syncTo)
 end
 
 -- Received a firstToLevel sync payload — deserialize and forward to tracker for merging.
+-- Accepts both the new table format {ftlstr, realmOpenedAt} and the old bare-string format.
 function TheClassicRaceSync:OnNetFTLSync(payload, sender)
     TheClassicRace:DebugPrint("OnNetFTLSync(" .. sender .. ")")
-    local ftldb = TheClassicRace.Serializer.DeserializeFTLBatch(payload)
-    self.EventBus:PublishEvent(self.Config.Events.FTLSyncResult, ftldb)
+    local ftlstr, remoteRealmOpenedAt
+    if type(payload) == "table" then
+        ftlstr = payload[1]
+        remoteRealmOpenedAt = payload[2]
+    else
+        ftlstr = payload
+    end
+    local ftldb = TheClassicRace.Serializer.DeserializeFTLBatch(ftlstr or "")
+    self.EventBus:PublishEvent(self.Config.Events.FTLSyncResult, ftldb, remoteRealmOpenedAt)
 end
 
 -- Called when the party roster changes. Debounced to avoid firing multiple times

--- a/src/core/sync.lua
+++ b/src/core/sync.lua
@@ -490,6 +490,7 @@ function TheClassicRaceSync:OnNetBuddyPing(payload, sender)
 
     if not leaderboardsDiffer and not ftlDiffers then return end
 
+    local diffClasses = {}
     if leaderboardsDiffer then
         local senderPerClassHashes = payload[2]
         for classIndex = 0, #self.Config.Classes do
@@ -498,6 +499,7 @@ function TheClassicRaceSync:OnNetBuddyPing(payload, sender)
                 local myHash = myPerClassHashes[classIndex + 1]
                 local theirHash = senderPerClassHashes and senderPerClassHashes[classIndex + 1] or 0
                 if myHash ~= theirHash then
+                    diffClasses[#diffClasses + 1] = classIndex
                     self:Sync(sender, classIndex)
                 end
             end
@@ -506,6 +508,10 @@ function TheClassicRaceSync:OnNetBuddyPing(payload, sender)
 
     if ftlDiffers then
         self:SyncFTL(sender)
+    end
+
+    if leaderboardsDiffer or ftlDiffers then
+        TheClassicRace:AddHashLog(sender, ">", diffClasses, ftlDiffers)
     end
 end
 
@@ -526,6 +532,7 @@ function TheClassicRaceSync:OnNetBuddyPong(payload, sender)
     local leaderboardsDiffer = myFullHash ~= senderFullHash
     local ftlDiffers = senderFTLHash == nil or senderFTLHash ~= myFTLHash
 
+    local diffClasses = {}
     if leaderboardsDiffer then
         local senderPerClassHashes = payload[2]
         for classIndex = 0, #self.Config.Classes do
@@ -534,6 +541,7 @@ function TheClassicRaceSync:OnNetBuddyPong(payload, sender)
                 local myHash = TheClassicRace.Leaderboard.ComputeHash(lb)
                 local theirHash = senderPerClassHashes and senderPerClassHashes[classIndex + 1] or 0
                 if myHash ~= theirHash then
+                    diffClasses[#diffClasses + 1] = classIndex
                     self:Sync(sender, classIndex)
                 end
             end
@@ -542,6 +550,10 @@ function TheClassicRaceSync:OnNetBuddyPong(payload, sender)
 
     if ftlDiffers then
         self:SyncFTL(sender)
+    end
+
+    if leaderboardsDiffer or ftlDiffers then
+        TheClassicRace:AddHashLog(sender, ">", diffClasses, ftlDiffers)
     end
 end
 

--- a/src/core/sync.lua
+++ b/src/core/sync.lua
@@ -17,6 +17,29 @@ local function computeFullHash(db, config)
     return hash
 end
 
+-- djb2 hash over all firstToLevel records in deterministic order
+local function computeFTLHash(db)
+    local hash = 5381
+    local ftl = db.factionrealm.firstToLevel
+    if not ftl then return hash end
+    for classFilter = 0, 11 do
+        local levels = ftl[classFilter]
+        if levels then
+            for level = 2, 90 do
+                local record = levels[level]
+                if record then
+                    local entry = classFilter .. level .. record.name
+                            .. (record.classIndex or 0) .. math.floor(record.dingedAt or 0)
+                    for i = 1, #entry do
+                        hash = ((hash * 33) + string.byte(entry, i)) % 2147483647
+                    end
+                end
+            end
+        end
+    end
+    return hash
+end
+
 --[[
 TheClassicRaceSync handles both requesting a sync when we login and responding to others who are request a sync
 ]]--
@@ -59,6 +82,7 @@ function TheClassicRaceSync.new(Config, Core, DB, EventBus, Network)
     EventBus:RegisterCallback(self.Config.Network.Events.GuildOffer, self, self.OnNetGuildOffer)
     EventBus:RegisterCallback(self.Config.Network.Events.BuddyPing, self, self.OnNetBuddyPing)
     EventBus:RegisterCallback(self.Config.Network.Events.BuddyPong, self, self.OnNetBuddyPong)
+    EventBus:RegisterCallback(self.Config.Network.Events.FTLSync, self, self.OnNetFTLSync)
 
     return self
 end
@@ -73,11 +97,12 @@ function TheClassicRaceSync:InitSync()
         return
     end
 
-    -- include our leaderboard hashes so partners can skip offering when already in sync
+    -- include our leaderboard and FTL hashes so partners can skip offering when already in sync
     local globalHash = TheClassicRace.Leaderboard.ComputeHash(self.DB.factionrealm.leaderboard[0])
     local classHash = TheClassicRace.Leaderboard.ComputeHash(
             self.DB.factionrealm.leaderboard[self.classIndex] or {players = {}})
-    local payload = {self.classIndex, globalHash, classHash}
+    local ftlHash = computeFTLHash(self.DB)
+    local payload = {self.classIndex, globalHash, classHash, ftlHash}
 
     self.Network:SendObject(self.Config.Network.Events.RequestSync, payload, "YELL")
 
@@ -102,9 +127,10 @@ function TheClassicRaceSync:OnNetRequestSync(payload, sender)
     end
 
     -- extract requester's classIndex and hashes (payload is a table in new clients, plain number in old)
-    local requesterClassIndex, requesterGlobalHash, requesterClassHash
+    local requesterClassIndex, requesterGlobalHash, requesterClassHash, requesterFTLHash
     if type(payload) == "table" then
-        requesterClassIndex, requesterGlobalHash, requesterClassHash = payload[1], payload[2], payload[3]
+        requesterClassIndex, requesterGlobalHash, requesterClassHash, requesterFTLHash =
+                payload[1], payload[2], payload[3], payload[4]
     else
         requesterClassIndex = payload
     end
@@ -113,9 +139,11 @@ function TheClassicRaceSync:OnNetRequestSync(payload, sender)
     local myGlobalHash = TheClassicRace.Leaderboard.ComputeHash(self.DB.factionrealm.leaderboard[0])
     local myClassHash = TheClassicRace.Leaderboard.ComputeHash(
             self.DB.factionrealm.leaderboard[self.classIndex] or {players = {}})
+    local myFTLHash = computeFTLHash(self.DB)
 
     -- skip offering if the requester already has identical data to us
-    if requesterGlobalHash ~= nil and requesterGlobalHash == myGlobalHash then
+    if requesterGlobalHash ~= nil and requesterGlobalHash == myGlobalHash
+            and (requesterFTLHash == nil or requesterFTLHash == myFTLHash) then
         local classSyncNeeded = requesterClassIndex == self.classIndex
                 and requesterClassHash ~= nil
                 and requesterClassHash ~= myClassHash
@@ -126,15 +154,15 @@ function TheClassicRaceSync:OnNetRequestSync(payload, sender)
     end
 
     self.Network:SendObject(self.Config.Network.Events.OfferSync,
-            { self.classIndex, self.lastSync, myGlobalHash, myClassHash }, "WHISPER", sender)
+            { self.classIndex, self.lastSync, myGlobalHash, myClassHash, myFTLHash }, "WHISPER", sender)
 end
 
 function TheClassicRaceSync:OnNetOfferSync(offer, sender)
-    local classIndex, lastSync, globalHash, classHash = offer[1], offer[2], offer[3], offer[4]
+    local classIndex, lastSync, globalHash, classHash, ftlHash = offer[1], offer[2], offer[3], offer[4], offer[5]
     TheClassicRace:DebugPrint("OnNetOfferSync(" .. sender .. ")")
     -- add anyone who offers to sync with us
     table.insert(self.offers, {name = sender, classIndex = classIndex, lastSync = lastSync,
-                               globalHash = globalHash, classHash = classHash})
+                               globalHash = globalHash, classHash = classHash, ftlHash = ftlHash})
     self:AddBuddy(sender)
 end
 
@@ -211,20 +239,22 @@ function TheClassicRaceSync:DoSync()
     local sameClass = self.syncPartner.classIndex == self.classIndex
     local myClassHash = sameClass and TheClassicRace.Leaderboard.ComputeHash(
             self.DB.factionrealm.leaderboard[self.classIndex] or {players = {}})
+    local myFTLHash = computeFTLHash(self.DB)
 
     local globalMatch = self.syncPartner.globalHash ~= nil and self.syncPartner.globalHash == myGlobalHash
     local classMatch = not sameClass
             or (self.syncPartner.classHash ~= nil and self.syncPartner.classHash == myClassHash)
+    local ftlMatch = self.syncPartner.ftlHash ~= nil and self.syncPartner.ftlHash == myFTLHash
 
-    if globalMatch and classMatch then
+    if globalMatch and classMatch and ftlMatch then
         TheClassicRace:DebugPrint("Already in sync with " .. self.syncPartner.name)
         self:SetReady()
         return
     end
 
-    -- include our hashes so the partner can also skip sending back leaderboards we already agree on
+    -- include our hashes so the partner can also skip sending back data we already agree on
     self.Network:SendObject(self.Config.Network.Events.StartSync,
-            {self.classIndex, myGlobalHash, myClassHash}, "WHISPER", self.syncPartner.name)
+            {self.classIndex, myGlobalHash, myClassHash, myFTLHash}, "WHISPER", self.syncPartner.name)
 
     -- check if we need to retry syncing after a short timeout
     local _self = self
@@ -234,12 +264,15 @@ function TheClassicRaceSync:DoSync()
         end
     end)
 
-    -- only send leaderboards that the partner doesn't already have
+    -- only send leaderboards / FTL data the partner doesn't already have
     if not globalMatch then
         self:Sync(self.syncPartner.name, 0)
     end
     if sameClass and not classMatch then
         self:Sync(self.syncPartner.name, self.classIndex)
+    end
+    if not ftlMatch then
+        self:SyncFTL(self.syncPartner.name)
     end
 end
 
@@ -253,7 +286,7 @@ function TheClassicRaceSync:OnNetStartSync(payload, sender)
     TheClassicRace:DebugPrint("OnNetStartSync(" .. sender .. ")")
     self.lastSync = self.Core:Now()
 
-    local requesterClassIndex, requesterGlobalHash, requesterClassHash
+    local requesterClassIndex, requesterGlobalHash, requesterClassHash, requesterFTLHash
     if type(payload) == "table" then
         requesterClassIndex = payload[1]
 
@@ -269,11 +302,13 @@ function TheClassicRaceSync:OnNetStartSync(payload, sender)
                     end
                 end
             end
+            -- guild sync always sends FTL (no per-guild FTL hash negotiated)
+            self:SyncFTL(sender)
             return
         end
 
-        -- zone sync: payload[2] is globalHash, payload[3] is classHash
-        requesterGlobalHash, requesterClassHash = payload[2], payload[3]
+        -- zone sync: payload[2] is globalHash, payload[3] is classHash, payload[4] is ftlHash
+        requesterGlobalHash, requesterClassHash, requesterFTLHash = payload[2], payload[3], payload[4]
     else
         requesterClassIndex = payload
     end
@@ -290,6 +325,11 @@ function TheClassicRaceSync:OnNetStartSync(payload, sender)
         if requesterClassHash == nil or requesterClassHash ~= myClassHash then
             self:Sync(sender, self.classIndex)
         end
+    end
+
+    local myFTLHash = computeFTLHash(self.DB)
+    if requesterFTLHash == nil or requesterFTLHash ~= myFTLHash then
+        self:SyncFTL(sender)
     end
 end
 
@@ -412,7 +452,8 @@ function TheClassicRaceSync:SendBuddyPings()
         local lb = self.DB.factionrealm.leaderboard[classIndex]
         myPerClassHashes[classIndex + 1] = lb and TheClassicRace.Leaderboard.ComputeHash(lb) or 0
     end
-    local payload = {myFullHash, myPerClassHashes}
+    local myFTLHash = computeFTLHash(self.DB)
+    local payload = {myFullHash, myPerClassHashes, myFTLHash}
 
     TheClassicRace:DebugPrint("BuddyPing: pinging " .. #selected .. " of " .. #names .. " buddies")
     for _, name in ipairs(selected) do
@@ -432,30 +473,42 @@ function TheClassicRaceSync:OnNetBuddyPing(payload, sender)
         local lb = self.DB.factionrealm.leaderboard[classIndex]
         myPerClassHashes[classIndex + 1] = lb and TheClassicRace.Leaderboard.ComputeHash(lb) or 0
     end
+    local myFTLHash = computeFTLHash(self.DB)
 
     -- always ack with our hashes so the sender knows we're online and can push back
     self.Network:SendObject(self.Config.Network.Events.BuddyPong,
-            {myFullHash, myPerClassHashes}, "WHISPER", sender)
+            {myFullHash, myPerClassHashes, myFTLHash}, "WHISPER", sender)
 
     if not self.isReady then return end
 
     local senderFullHash = payload[1]
-    if myFullHash == senderFullHash then return end
+    local senderFTLHash = payload[3]
 
-    local senderPerClassHashes = payload[2]
-    for classIndex = 0, #self.Config.Classes do
-        local lb = self.DB.factionrealm.leaderboard[classIndex]
-        if lb and #lb.players > 0 then
-            local myHash = myPerClassHashes[classIndex + 1]
-            local theirHash = senderPerClassHashes and senderPerClassHashes[classIndex + 1] or 0
-            if myHash ~= theirHash then
-                self:Sync(sender, classIndex)
+    local leaderboardsDiffer = myFullHash ~= senderFullHash
+    local ftlDiffers = senderFTLHash == nil or senderFTLHash ~= myFTLHash
+
+    if not leaderboardsDiffer and not ftlDiffers then return end
+
+    if leaderboardsDiffer then
+        local senderPerClassHashes = payload[2]
+        for classIndex = 0, #self.Config.Classes do
+            local lb = self.DB.factionrealm.leaderboard[classIndex]
+            if lb and #lb.players > 0 then
+                local myHash = myPerClassHashes[classIndex + 1]
+                local theirHash = senderPerClassHashes and senderPerClassHashes[classIndex + 1] or 0
+                if myHash ~= theirHash then
+                    self:Sync(sender, classIndex)
+                end
             end
         end
     end
+
+    if ftlDiffers then
+        self:SyncFTL(sender)
+    end
 end
 
--- Received BPONG from a buddy: update their last-seen, push any leaderboards they're missing.
+-- Received BPONG from a buddy: update their last-seen, push any leaderboards / FTL they're missing.
 function TheClassicRaceSync:OnNetBuddyPong(payload, sender)
     self:AddBuddy(sender)
     TheClassicRace:DebugPrint("BuddyPong from " .. sender)
@@ -466,19 +519,42 @@ function TheClassicRaceSync:OnNetBuddyPong(payload, sender)
     if not senderFullHash then return end
 
     local myFullHash = computeFullHash(self.DB, self.Config)
-    if myFullHash == senderFullHash then return end
+    local myFTLHash = computeFTLHash(self.DB)
+    local senderFTLHash = payload[3]
 
-    local senderPerClassHashes = payload[2]
-    for classIndex = 0, #self.Config.Classes do
-        local lb = self.DB.factionrealm.leaderboard[classIndex]
-        if lb and #lb.players > 0 then
-            local myHash = TheClassicRace.Leaderboard.ComputeHash(lb)
-            local theirHash = senderPerClassHashes and senderPerClassHashes[classIndex + 1] or 0
-            if myHash ~= theirHash then
-                self:Sync(sender, classIndex)
+    local leaderboardsDiffer = myFullHash ~= senderFullHash
+    local ftlDiffers = senderFTLHash == nil or senderFTLHash ~= myFTLHash
+
+    if leaderboardsDiffer then
+        local senderPerClassHashes = payload[2]
+        for classIndex = 0, #self.Config.Classes do
+            local lb = self.DB.factionrealm.leaderboard[classIndex]
+            if lb and #lb.players > 0 then
+                local myHash = TheClassicRace.Leaderboard.ComputeHash(lb)
+                local theirHash = senderPerClassHashes and senderPerClassHashes[classIndex + 1] or 0
+                if myHash ~= theirHash then
+                    self:Sync(sender, classIndex)
+                end
             end
         end
     end
+
+    if ftlDiffers then
+        self:SyncFTL(sender)
+    end
+end
+
+-- Whispers our complete firstToLevel dataset to the target player.
+function TheClassicRaceSync:SyncFTL(syncTo)
+    local ftlstr = TheClassicRace.Serializer.SerializeFTLBatch(self.DB.factionrealm.firstToLevel or {})
+    self.Network:SendObject(self.Config.Network.Events.FTLSync, ftlstr, "WHISPER", syncTo)
+end
+
+-- Received a firstToLevel sync payload — deserialize and forward to tracker for merging.
+function TheClassicRaceSync:OnNetFTLSync(payload, sender)
+    TheClassicRace:DebugPrint("OnNetFTLSync(" .. sender .. ")")
+    local ftldb = TheClassicRace.Serializer.DeserializeFTLBatch(payload)
+    self.EventBus:PublishEvent(self.Config.Events.FTLSyncResult, ftldb)
 end
 
 -- Called when the party roster changes. Debounced to avoid firing multiple times
@@ -510,7 +586,8 @@ function TheClassicRaceSync:SendGroupSync()
         local lb = self.DB.factionrealm.leaderboard[classIndex]
         myPerClassHashes[classIndex + 1] = lb and TheClassicRace.Leaderboard.ComputeHash(lb) or 0
     end
-    self.Network:SendObject(self.Config.Network.Events.BuddyPing, {myFullHash, myPerClassHashes}, "GROUP")
+    local myFTLHash = computeFTLHash(self.DB)
+    self.Network:SendObject(self.Config.Network.Events.BuddyPing, {myFullHash, myPerClassHashes, myFTLHash}, "GROUP")
 end
 
 -- Start the periodic buddy ping ticker.

--- a/src/core/sync.lua
+++ b/src/core/sync.lua
@@ -421,6 +421,7 @@ function TheClassicRaceSync:AddBuddy(name)
     end
     buddies[name].lastSeen = self.Core:Now()
     TheClassicRace:DebugPrint("Buddy: added/updated " .. name)
+    self.EventBus:PublishEvent(self.Config.Events.BuddyUpdate)
 end
 
 -- Send BPING to up to BuddyPingBatchSize buddies (random sample if more).

--- a/src/core/sync.lua
+++ b/src/core/sync.lua
@@ -17,19 +17,22 @@ local function computeFullHash(db, config)
     return hash
 end
 
--- djb2 hash over all firstToLevel records in deterministic order
-local function computeFTLHash(db)
+-- djb2 hash over all firstToLevel records in deterministic order.
+-- Covers every classFilter the serializer transmits (0 = overall, 1..#Classes)
+-- and the full 2-digit level range of the wire format; fields are ':'-separated
+-- so different records can't concatenate to the same entry string.
+local function computeFTLHash(db, config)
     local hash = 5381
     local ftl = db.factionrealm.firstToLevel
     if not ftl then return hash end
-    for classFilter = 0, 11 do
+    for classFilter = 0, #config.Classes do
         local levels = ftl[classFilter]
         if levels then
-            for level = 2, 90 do
+            for level = 2, 99 do
                 local record = levels[level]
                 if record then
-                    local entry = classFilter .. level .. record.name
-                            .. (record.classIndex or 0) .. math.floor(record.dingedAt or 0)
+                    local entry = classFilter .. ":" .. level .. ":" .. record.name .. ":"
+                            .. (record.classIndex or 0) .. ":" .. math.floor(record.dingedAt or 0)
                     for i = 1, #entry do
                         hash = ((hash * 33) + string.byte(entry, i)) % 2147483647
                     end
@@ -56,6 +59,10 @@ setmetatable(TheClassicRaceSync, {
         return cls.new(...)
     end,
 })
+
+-- exposed as statics for tests and diagnostics
+TheClassicRaceSync.ComputeFTLHash = computeFTLHash
+TheClassicRaceSync.ComputeFullHash = computeFullHash
 
 function TheClassicRaceSync.new(Config, Core, DB, EventBus, Network)
     local self = setmetatable({}, TheClassicRaceSync)
@@ -101,7 +108,7 @@ function TheClassicRaceSync:InitSync()
     local globalHash = TheClassicRace.Leaderboard.ComputeHash(self.DB.factionrealm.leaderboard[0])
     local classHash = TheClassicRace.Leaderboard.ComputeHash(
             self.DB.factionrealm.leaderboard[self.classIndex] or {players = {}})
-    local ftlHash = computeFTLHash(self.DB)
+    local ftlHash = computeFTLHash(self.DB, self.Config)
     local payload = {self.classIndex, globalHash, classHash, ftlHash}
 
     self.Network:SendObject(self.Config.Network.Events.RequestSync, payload, "YELL")
@@ -139,7 +146,7 @@ function TheClassicRaceSync:OnNetRequestSync(payload, sender)
     local myGlobalHash = TheClassicRace.Leaderboard.ComputeHash(self.DB.factionrealm.leaderboard[0])
     local myClassHash = TheClassicRace.Leaderboard.ComputeHash(
             self.DB.factionrealm.leaderboard[self.classIndex] or {players = {}})
-    local myFTLHash = computeFTLHash(self.DB)
+    local myFTLHash = computeFTLHash(self.DB, self.Config)
 
     -- skip offering if the requester already has identical data to us
     if requesterGlobalHash ~= nil and requesterGlobalHash == myGlobalHash
@@ -239,7 +246,7 @@ function TheClassicRaceSync:DoSync()
     local sameClass = self.syncPartner.classIndex == self.classIndex
     local myClassHash = sameClass and TheClassicRace.Leaderboard.ComputeHash(
             self.DB.factionrealm.leaderboard[self.classIndex] or {players = {}})
-    local myFTLHash = computeFTLHash(self.DB)
+    local myFTLHash = computeFTLHash(self.DB, self.Config)
 
     local globalMatch = self.syncPartner.globalHash ~= nil and self.syncPartner.globalHash == myGlobalHash
     local classMatch = not sameClass
@@ -283,6 +290,7 @@ function TheClassicRaceSync:Sync(syncTo, classIndex)
 end
 
 function TheClassicRaceSync:OnNetStartSync(payload, sender)
+    if not self.DB.profile.options.networking then return end
     TheClassicRace:DebugPrint("OnNetStartSync(" .. sender .. ")")
     self.lastSync = self.Core:Now()
 
@@ -302,8 +310,12 @@ function TheClassicRaceSync:OnNetStartSync(payload, sender)
                     end
                 end
             end
-            -- guild sync always sends FTL (no per-guild FTL hash negotiated)
-            self:SyncFTL(sender)
+            -- payload[3] is the requester's FTL hash; only send FTL when it differs
+            -- (older clients don't include it — send unconditionally for those)
+            local guildFTLHash = payload[3]
+            if guildFTLHash == nil or guildFTLHash ~= computeFTLHash(self.DB, self.Config) then
+                self:SyncFTL(sender)
+            end
             return
         end
 
@@ -327,13 +339,14 @@ function TheClassicRaceSync:OnNetStartSync(payload, sender)
         end
     end
 
-    local myFTLHash = computeFTLHash(self.DB)
+    local myFTLHash = computeFTLHash(self.DB, self.Config)
     if requesterFTLHash == nil or requesterFTLHash ~= myFTLHash then
         self:SyncFTL(sender)
     end
 end
 
 function TheClassicRaceSync:OnNetSyncPayload(payload, sender)
+    if not self.DB.profile.options.networking then return end
     TheClassicRace:DebugPrint("OnNetSyncPayload(" .. sender .. ")")
 
     local batch = TheClassicRace.Serializer.DeserializePlayerInfoBatch(payload)
@@ -368,8 +381,9 @@ function TheClassicRaceSync:SendGuildSync()
     self.guildOffers = {}
 
     local fullHash = computeFullHash(self.DB, self.Config)
+    local ftlHash = computeFTLHash(self.DB, self.Config)
     self.Network:SendObject(self.Config.Network.Events.GuildSync,
-            {self.classIndex, fullHash, self.Core:LoginTime()}, "GUILD")
+            {self.classIndex, fullHash, self.Core:LoginTime(), ftlHash}, "GUILD")
 
     local _self = self
     C_Timer.After(self.Config.GuildSyncWait + 1, function()
@@ -383,10 +397,13 @@ function TheClassicRaceSync:OnNetGuildSync(payload, sender)
     if not self.DB.profile.options.networking then return end
     if not self.isReady then return end
 
-    local _, requesterFullHash, _ = payload[1], payload[2], payload[3]
+    local requesterFullHash, requesterFTLHash = payload[2], payload[4]
 
     local myFullHash = computeFullHash(self.DB, self.Config)
-    if myFullHash == requesterFullHash then return end
+    local myFTLHash = computeFTLHash(self.DB, self.Config)
+    -- older clients don't announce an FTL hash; treat that as matching
+    local ftlDiffers = requesterFTLHash ~= nil and requesterFTLHash ~= myFTLHash
+    if myFullHash == requesterFullHash and not ftlDiffers then return end
 
     local delay = math.random(0, self.Config.GuildSyncWait)
     local _self = self
@@ -395,7 +412,8 @@ function TheClassicRaceSync:OnNetGuildSync(payload, sender)
         local myClassHash = TheClassicRace.Leaderboard.ComputeHash(
                 _self.DB.factionrealm.leaderboard[_self.classIndex] or {players = {}})
         _self.Network:SendObject(_self.Config.Network.Events.GuildOffer,
-                {_self.classIndex, _self.lastSync, myFullHash, myGlobalHash, myClassHash, _self.Core:LoginTime()},
+                {_self.classIndex, _self.lastSync, myFullHash, myGlobalHash, myClassHash, _self.Core:LoginTime(),
+                 computeFTLHash(_self.DB, _self.Config)},
                 "WHISPER", sender)
     end)
 end
@@ -403,18 +421,27 @@ end
 -- Collect guild offers during the open window.
 function TheClassicRaceSync:OnNetGuildOffer(offer, sender)
     if self.guildOffers == nil then return end
-    local classIndex, lastSync, fullHash, globalHash, classHash, loginTime =
-            offer[1], offer[2], offer[3], offer[4], offer[5], offer[6]
+    local classIndex, lastSync, fullHash, globalHash, classHash, loginTime, ftlHash =
+            offer[1], offer[2], offer[3], offer[4], offer[5], offer[6], offer[7]
     TheClassicRace:DebugPrint("GuildOffer from " .. sender)
     table.insert(self.guildOffers, {
         name = sender, classIndex = classIndex, lastSync = lastSync,
         fullHash = fullHash, globalHash = globalHash, classHash = classHash, loginTime = loginTime,
+        ftlHash = ftlHash,
     })
 end
 
 -- Add or update a buddy entry in the persistent DB list.
 function TheClassicRaceSync:AddBuddy(name)
-    if name == self.Core:FullRealMe() then return end
+    -- sender format differs per channel (YELL gives "Name", GUILD/WHISPER give
+    -- "Name-Realm") — normalize same-realm names so we don't store duplicates
+    local shortName, realm = self.Core:SplitFullPlayer(name)
+    if self.Core:IsMyRealm(realm) then
+        if shortName == self.Core:RealMe() then return end
+        name = shortName
+    elseif name == self.Core:FullRealMe() then
+        return
+    end
     local buddies = self.DB.factionrealm.buddies
     if not buddies[name] then
         buddies[name] = {}
@@ -453,7 +480,7 @@ function TheClassicRaceSync:SendBuddyPings()
         local lb = self.DB.factionrealm.leaderboard[classIndex]
         myPerClassHashes[classIndex + 1] = lb and TheClassicRace.Leaderboard.ComputeHash(lb) or 0
     end
-    local myFTLHash = computeFTLHash(self.DB)
+    local myFTLHash = computeFTLHash(self.DB, self.Config)
     local payload = {myFullHash, myPerClassHashes, myFTLHash}
 
     TheClassicRace:DebugPrint("BuddyPing: pinging " .. #selected .. " of " .. #names .. " buddies")
@@ -474,7 +501,7 @@ function TheClassicRaceSync:OnNetBuddyPing(payload, sender)
         local lb = self.DB.factionrealm.leaderboard[classIndex]
         myPerClassHashes[classIndex + 1] = lb and TheClassicRace.Leaderboard.ComputeHash(lb) or 0
     end
-    local myFTLHash = computeFTLHash(self.DB)
+    local myFTLHash = computeFTLHash(self.DB, self.Config)
 
     -- always ack with our hashes so the sender knows we're online and can push back
     self.Network:SendObject(self.Config.Network.Events.BuddyPong,
@@ -517,6 +544,7 @@ end
 
 -- Received BPONG from a buddy: update their last-seen, push any leaderboards / FTL they're missing.
 function TheClassicRaceSync:OnNetBuddyPong(payload, sender)
+    if not self.DB.profile.options.networking then return end
     self:AddBuddy(sender)
     TheClassicRace:DebugPrint("BuddyPong from " .. sender)
 
@@ -526,7 +554,7 @@ function TheClassicRaceSync:OnNetBuddyPong(payload, sender)
     if not senderFullHash then return end
 
     local myFullHash = computeFullHash(self.DB, self.Config)
-    local myFTLHash = computeFTLHash(self.DB)
+    local myFTLHash = computeFTLHash(self.DB, self.Config)
     local senderFTLHash = payload[3]
 
     local leaderboardsDiffer = myFullHash ~= senderFullHash
@@ -568,6 +596,7 @@ end
 -- Received a firstToLevel sync payload — deserialize and forward to tracker for merging.
 -- Accepts both the new table format {ftlstr, realmOpenedAt} and the old bare-string format.
 function TheClassicRaceSync:OnNetFTLSync(payload, sender)
+    if not self.DB.profile.options.networking then return end
     TheClassicRace:DebugPrint("OnNetFTLSync(" .. sender .. ")")
     local ftlstr, remoteRealmOpenedAt
     if type(payload) == "table" then
@@ -578,6 +607,11 @@ function TheClassicRaceSync:OnNetFTLSync(payload, sender)
     end
     local ftldb = TheClassicRace.Serializer.DeserializeFTLBatch(ftlstr or "")
     self.EventBus:PublishEvent(self.Config.Events.FTLSyncResult, ftldb, remoteRealmOpenedAt)
+
+    -- an FTL payload also completes our initial sync: when only FTL differed from
+    -- our partner this is the only payload we'll receive, and without marking
+    -- ready we'd keep retrying other partners until the offer list runs dry
+    self:SetReady()
 end
 
 -- Called when the party roster changes. Debounced to avoid firing multiple times
@@ -609,7 +643,7 @@ function TheClassicRaceSync:SendGroupSync()
         local lb = self.DB.factionrealm.leaderboard[classIndex]
         myPerClassHashes[classIndex + 1] = lb and TheClassicRace.Leaderboard.ComputeHash(lb) or 0
     end
-    local myFTLHash = computeFTLHash(self.DB)
+    local myFTLHash = computeFTLHash(self.DB, self.Config)
     self.Network:SendObject(self.Config.Network.Events.BuddyPing, {myFullHash, myPerClassHashes, myFTLHash}, "GROUP")
 end
 
@@ -643,8 +677,11 @@ function TheClassicRaceSync:DoGuildSync()
 
     TheClassicRace:DebugPrint("DoGuildSync with " .. best.name)
 
-    -- sanity check: if full hashes match now, nothing to do
-    if best.fullHash == computeFullHash(self.DB, self.Config) then
+    -- sanity check: if full hashes (and FTL, when the partner announced one) match
+    -- now, nothing to do
+    local myFTLHash = computeFTLHash(self.DB, self.Config)
+    local ftlDiffers = best.ftlHash ~= nil and best.ftlHash ~= myFTLHash
+    if best.fullHash == computeFullHash(self.DB, self.Config) and not ftlDiffers then
         TheClassicRace:DebugPrint("Already in sync with guild partner " .. best.name)
         return
     end
@@ -657,6 +694,6 @@ function TheClassicRaceSync:DoGuildSync()
     end
 
     self.Network:SendObject(self.Config.Network.Events.StartSync,
-            {self.classIndex, myPerClassHashes}, "WHISPER", best.name)
+            {self.classIndex, myPerClassHashes, myFTLHash}, "WHISPER", best.name)
 end
 

--- a/src/core/tracker.lua
+++ b/src/core/tracker.lua
@@ -98,10 +98,6 @@ function TheClassicRaceTracker:OnNetPlayerInfoBatch(payload, _)
     local batch = TheClassicRace.Serializer.DeserializePlayerInfoBatch(batchstr)
     self:ProcessPlayerInfoBatch(batch, classIndex)
 
-    -- if it wasn't a rebroadcast then it was a /who scan, we can delay our own /who scan a bit
-    if not isRebroadcast then
-        self.EventBus:PublishEvent(self.Config.Events.BumpScan, classIndex)
-    end
 end
 
 function TheClassicRaceTracker:OnSlashWhoResult(playerInfoBatch, classIndex)

--- a/src/core/tracker.lua
+++ b/src/core/tracker.lua
@@ -45,6 +45,7 @@ function TheClassicRaceTracker.new(Config, Core, DB, EventBus, Network)
     -- subscribe to local events
     EventBus:RegisterCallback(self.Config.Events.SlashWhoResult, self, self.OnSlashWhoResult)
     EventBus:RegisterCallback(self.Config.Events.SyncResult, self, self.OnSyncResult)
+    EventBus:RegisterCallback(self.Config.Events.FTLSyncResult, self, self.OnFTLSyncResult)
     EventBus:RegisterCallback(self.Config.Events.ScanFinished, self, self.OnScanFinished)
 
     return self
@@ -338,6 +339,10 @@ function TheClassicRaceTracker:ProcessPlayerInfo(playerInfo)
         classRank, classIsChanged, classLowestLevel = self.lbPerClass[playerInfo.classIndex]:ProcessPlayerInfo(playerInfo)
     end
 
+    -- update pioneer records for every detected player
+    self:UpdatePioneers(playerInfo)
+    self:UpdatePlayerHistory(playerInfo)
+
     -- publish internal event
     if globalIsChanged or classIsChanged then
         self.EventBus:PublishEvent(self.Config.Events.Ding, playerInfo, globalRank, classRank)
@@ -350,4 +355,82 @@ function TheClassicRaceTracker:ProcessPlayerInfo(playerInfo)
 
     -- return normalized playerinfo and boolean if anything changed
     return playerInfo, globalIsChanged or classIsChanged
+end
+
+-- Records this player's dingedAt in playerHistory for future per-character level breakdown.
+function TheClassicRaceTracker:UpdatePlayerHistory(playerInfo)
+    local dingedAt = playerInfo.dingedAt
+    if dingedAt == nil then return end
+
+    local db = self.DB.factionrealm
+    local name = playerInfo.name
+    local level = playerInfo.level
+    local classIndex = playerInfo.classIndex
+
+    if db.playerHistory[name] == nil then
+        db.playerHistory[name] = {classIndex = classIndex, levels = {}}
+    end
+
+    local hist = db.playerHistory[name]
+    if hist.classIndex == nil and classIndex ~= nil then
+        hist.classIndex = classIndex
+    end
+    -- only keep the earliest detection at each level
+    if hist.levels[level] == nil or dingedAt < hist.levels[level] then
+        hist.levels[level] = dingedAt
+    end
+end
+
+-- Updates firstToLevel (overall and per-class) and raceStartedAt for every detected player.
+function TheClassicRaceTracker:UpdatePioneers(playerInfo)
+    local dingedAt = playerInfo.dingedAt
+    if dingedAt == nil then return end
+
+    local db = self.DB.factionrealm
+    local name = playerInfo.name
+    local level = playerInfo.level
+    local classIndex = playerInfo.classIndex
+
+    -- track the earliest detection as race start
+    if db.raceStartedAt == nil or dingedAt < db.raceStartedAt then
+        db.raceStartedAt = dingedAt
+    end
+
+    -- overall (classFilter 0)
+    if db.firstToLevel[0] == nil then db.firstToLevel[0] = {} end
+    local ftl0 = db.firstToLevel[0]
+    if ftl0[level] == nil or dingedAt < ftl0[level].dingedAt then
+        ftl0[level] = {name = name, classIndex = classIndex, dingedAt = dingedAt}
+    end
+
+    -- per-class
+    if classIndex ~= nil and classIndex ~= 0 then
+        if db.firstToLevel[classIndex] == nil then db.firstToLevel[classIndex] = {} end
+        local ftlC = db.firstToLevel[classIndex]
+        if ftlC[level] == nil or dingedAt < ftlC[level].dingedAt then
+            ftlC[level] = {name = name, classIndex = classIndex, dingedAt = dingedAt}
+        end
+    end
+end
+
+-- Merges received firstToLevel data from a sync partner, keeping the earliest record per slot.
+function TheClassicRaceTracker:OnFTLSyncResult(ftldb)
+    local db = self.DB.factionrealm
+
+    for classFilter, levels in pairs(ftldb) do
+        if db.firstToLevel[classFilter] == nil then
+            db.firstToLevel[classFilter] = {}
+        end
+        for level, record in pairs(levels) do
+            local existing = db.firstToLevel[classFilter][level]
+            if existing == nil or record.dingedAt < existing.dingedAt then
+                db.firstToLevel[classFilter][level] = record
+                if db.raceStartedAt == nil or record.dingedAt < db.raceStartedAt then
+                    db.raceStartedAt = record.dingedAt
+                end
+            end
+        end
+    end
+
+    self.EventBus:PublishEvent(self.Config.Events.RefreshGUI)
 end

--- a/src/core/tracker.lua
+++ b/src/core/tracker.lua
@@ -399,7 +399,8 @@ function TheClassicRaceTracker:UpdatePioneers(playerInfo)
     -- overall (classFilter 0)
     if db.firstToLevel[0] == nil then db.firstToLevel[0] = {} end
     local ftl0 = db.firstToLevel[0]
-    if ftl0[level] == nil or dingedAt < ftl0[level].dingedAt then
+    if ftl0[level] == nil or dingedAt < ftl0[level].dingedAt
+            or (dingedAt == ftl0[level].dingedAt and name < ftl0[level].name) then
         ftl0[level] = {name = name, classIndex = classIndex, dingedAt = dingedAt}
     end
 
@@ -407,7 +408,8 @@ function TheClassicRaceTracker:UpdatePioneers(playerInfo)
     if classIndex ~= nil and classIndex ~= 0 then
         if db.firstToLevel[classIndex] == nil then db.firstToLevel[classIndex] = {} end
         local ftlC = db.firstToLevel[classIndex]
-        if ftlC[level] == nil or dingedAt < ftlC[level].dingedAt then
+        if ftlC[level] == nil or dingedAt < ftlC[level].dingedAt
+                or (dingedAt == ftlC[level].dingedAt and name < ftlC[level].name) then
             ftlC[level] = {name = name, classIndex = classIndex, dingedAt = dingedAt}
         end
     end
@@ -423,7 +425,8 @@ function TheClassicRaceTracker:OnFTLSyncResult(ftldb)
         end
         for level, record in pairs(levels) do
             local existing = db.firstToLevel[classFilter][level]
-            if existing == nil or record.dingedAt < existing.dingedAt then
+            if existing == nil or record.dingedAt < existing.dingedAt
+                    or (record.dingedAt == existing.dingedAt and record.name < existing.name) then
                 db.firstToLevel[classFilter][level] = record
                 if db.raceStartedAt == nil or record.dingedAt < db.raceStartedAt then
                     db.raceStartedAt = record.dingedAt

--- a/src/core/tracker.lua
+++ b/src/core/tracker.lua
@@ -416,8 +416,13 @@ function TheClassicRaceTracker:UpdatePioneers(playerInfo)
 end
 
 -- Merges received firstToLevel data from a sync partner, keeping the earliest record per slot.
-function TheClassicRaceTracker:OnFTLSyncResult(ftldb)
+-- Also merges realmOpenedAt, keeping the earliest (closest to actual realm launch).
+function TheClassicRaceTracker:OnFTLSyncResult(ftldb, remoteRealmOpenedAt)
     local db = self.DB.factionrealm
+
+    if remoteRealmOpenedAt and (db.realmOpenedAt == nil or remoteRealmOpenedAt < db.realmOpenedAt) then
+        db.realmOpenedAt = remoteRealmOpenedAt
+    end
 
     for classFilter, levels in pairs(ftldb) do
         if db.firstToLevel[classFilter] == nil then

--- a/src/core/tracker.lua
+++ b/src/core/tracker.lua
@@ -324,6 +324,11 @@ function TheClassicRaceTracker:ProcessDiscoveryResponses()
 
     if #requesters == 1 then
         local needSet = self:ComputeNeedSet(requesters[1].classHashes)
+        if needSet then
+            local classes = {}
+            for ci in pairs(needSet) do classes[#classes + 1] = ci end
+            TheClassicRace:AddHashLog(requesters[1].name, ">", classes, false)
+        end
         local batches = self:CollectBatches(needSet)
         if batches then
             self:SendBatches(batches, "WHISPER", requesters[1].name)
@@ -340,6 +345,11 @@ function TheClassicRaceTracker:ProcessDiscoveryResponses()
             for classIndex, _ in pairs(needSet) do
                 unionNeedSet[classIndex] = true
             end
+        end
+        if unionNeedSet then
+            local classes = {}
+            for ci in pairs(unionNeedSet) do classes[#classes + 1] = ci end
+            TheClassicRace:AddHashLog("(zone yell)", ">", classes, false)
         end
         local batches = self:CollectBatches(unionNeedSet)
         if batches then

--- a/src/core/tracker.lua
+++ b/src/core/tracker.lua
@@ -2,7 +2,7 @@
 local TheClassicRace = _G.TheClassicRace
 
 -- WoW API
-local C_Timer = _G.C_Timer
+local C_Timer, IsInGuild, math = _G.C_Timer, _G.IsInGuild, _G.math
 
 --[[
 Tracker is responsible for maintaining our leaderboard data based on data provided by other parts of the system
@@ -35,6 +35,8 @@ function TheClassicRaceTracker.new(Config, Core, DB, EventBus, Network)
     self.Network = Network
 
     self.pendingRequesters = nil   -- non-nil only during active discovery window
+    self.pendingDings = {}
+    self.dingPushPending = false
 
     self:ReinitLeaderboards()
 
@@ -101,11 +103,78 @@ function TheClassicRaceTracker:OnNetPlayerInfoBatch(payload, _)
 end
 
 function TheClassicRaceTracker:OnSlashWhoResult(playerInfoBatch, classIndex)
-    self:ProcessPlayerInfoBatch(playerInfoBatch, classIndex)
+    local changed = {}
+    for _, playerInfo in ipairs(playerInfoBatch) do
+        local normalizedInfo, isChanged = self:ProcessPlayerInfo(playerInfo)
+        if isChanged then
+            changed[#changed + 1] = normalizedInfo
+        end
+    end
+    if #changed > 0 then
+        self:ScheduleDingPush(changed)
+    end
 end
 
 function TheClassicRaceTracker:OnSyncResult(playerInfoBatch)
     self:ProcessPlayerInfoBatch(playerInfoBatch)
+end
+
+function TheClassicRaceTracker:ScheduleDingPush(changedPlayers)
+    if not self.DB.profile.options.networking then return end
+    if self.DB.factionrealm.finished then return end
+
+    -- YELL immediately so zone players get real-time updates
+    local batchstr = TheClassicRace.Serializer.SerializePlayerInfoBatch(changedPlayers)
+    self.Network:SendObject(self.Config.Network.Events.PlayerInfoBatch, {batchstr, false, 0}, "YELL")
+
+    -- accumulate into pending set (keyed by name to deduplicate across rapid scans)
+    for _, p in ipairs(changedPlayers) do
+        self.pendingDings[p.name] = p
+    end
+
+    if not self.dingPushPending then
+        self.dingPushPending = true
+        local _self = self
+        C_Timer.After(self.Config.DingPushDelay, function()
+            _self:FlushDingPush()
+        end)
+    end
+end
+
+function TheClassicRaceTracker:FlushDingPush()
+    self.dingPushPending = false
+
+    local players = {}
+    for _, p in pairs(self.pendingDings) do
+        players[#players + 1] = p
+    end
+    self.pendingDings = {}
+
+    if #players == 0 then return end
+
+    local batchstr = TheClassicRace.Serializer.SerializePlayerInfoBatch(players)
+    local payload = {batchstr, false, 0}
+
+    if IsInGuild() then
+        self.Network:SendObject(self.Config.Network.Events.PlayerInfoBatch, payload, "GUILD")
+    end
+
+    -- whisper a random sample of buddies (capped at BuddyPingBatchSize)
+    local names = {}
+    for name, _ in pairs(self.DB.factionrealm.buddies) do
+        names[#names + 1] = name
+    end
+    local batchSize = self.Config.BuddyPingBatchSize
+    if #names > batchSize then
+        for i = 1, batchSize do
+            local j = math.random(i, #names)
+            names[i], names[j] = names[j], names[i]
+        end
+        for i = batchSize + 1, #names do names[i] = nil end
+    end
+    for _, name in ipairs(names) do
+        self.Network:SendObject(self.Config.Network.Events.PlayerInfoBatch, payload, "WHISPER", name)
+    end
 end
 
 function TheClassicRaceTracker:ProcessPlayerInfoBatch(playerInfoBatch, classIndex)

--- a/src/core/tracker.lua
+++ b/src/core/tracker.lua
@@ -39,6 +39,7 @@ function TheClassicRaceTracker.new(Config, Core, DB, EventBus, Network)
     self.dingPushPending = false
 
     self:ReinitLeaderboards()
+    self:NormalizeDB()
 
     -- subscribe to network events
     EventBus:RegisterCallback(self.Config.Network.Events.PlayerInfoBatch, self, self.OnNetPlayerInfoBatch)
@@ -58,6 +59,34 @@ function TheClassicRaceTracker:ReinitLeaderboards()
     self.lbPerClass = {}
     for classIndex, _ in ipairs(self.Config.Classes) do
         self.lbPerClass[classIndex] = TheClassicRace.Leaderboard(self.Config, self.DB.factionrealm.leaderboard[classIndex])
+    end
+end
+
+-- Heals data persisted by older versions: floors fractional timestamps and re-sorts
+-- every leaderboard into the canonical order. Stored order predating the deterministic
+-- sort otherwise causes permanent hash mismatches between clients holding identical data.
+function TheClassicRaceTracker:NormalizeDB()
+    for classIndex = 0, #self.Config.Classes do
+        local lb = self.DB.factionrealm.leaderboard[classIndex]
+        if lb then
+            for _, player in ipairs(lb.players) do
+                if player.dingedAt ~= nil then
+                    player.dingedAt = math.floor(player.dingedAt)
+                end
+            end
+            TheClassicRace.Leaderboard.SortPlayers(lb.players)
+        end
+    end
+
+    local ftl = self.DB.factionrealm.firstToLevel
+    if ftl then
+        for _, levels in pairs(ftl) do
+            for _, record in pairs(levels) do
+                if record.dingedAt ~= nil then
+                    record.dingedAt = math.floor(record.dingedAt)
+                end
+            end
+        end
     end
 end
 
@@ -362,6 +391,8 @@ end
 -- If ours differs, whisper back a data request with our per-class hashes
 -- so the responder can skip sending leaderboards we already agree on.
 function TheClassicRaceTracker:OnNetDataAvailable(hash, sender)
+    if not self.DB.profile.options.networking then return end
+
     local myHash = self:ComputeFullHash()
     if myHash == hash then return end
 
@@ -379,6 +410,7 @@ end
 -- Received when someone wants our data. Only accepted during the active
 -- discovery window opened by SendDiscoveryBeacon.
 function TheClassicRaceTracker:OnNetDataRequest(classHashes, sender)
+    if not self.DB.profile.options.networking then return end
     if self.pendingRequesters == nil then return end
     for _, req in ipairs(self.pendingRequesters) do
         if req.name == sender then return end
@@ -399,6 +431,9 @@ function TheClassicRaceTracker:ProcessPlayerInfo(playerInfo)
     if playerInfo.dingedAt == nil then
         playerInfo.dingedAt = self.Core:Now()
     end
+    -- keep timestamps integral: the wire format truncates to whole seconds, so a
+    -- fractional local value would hash differently from its synced copy
+    playerInfo.dingedAt = math.floor(playerInfo.dingedAt)
 
     if playerInfo.classIndex == nil and playerInfo.class ~= nil then
         playerInfo.classIndex = self.Core:ClassIndex(playerInfo.class)
@@ -410,7 +445,8 @@ function TheClassicRaceTracker:ProcessPlayerInfo(playerInfo)
 
     local globalRank, globalIsChanged = self.lbGlobal:ProcessPlayerInfo(playerInfo)
     local classRank, classIsChanged, classLowestLevel = nil, nil
-    if playerInfo.classIndex ~= nil then
+    -- classIndex 0 (unknown class) has no class leaderboard
+    if playerInfo.classIndex ~= nil and self.lbPerClass[playerInfo.classIndex] ~= nil then
         classRank, classIsChanged, classLowestLevel = self.lbPerClass[playerInfo.classIndex]:ProcessPlayerInfo(playerInfo)
     end
 
@@ -456,6 +492,26 @@ function TheClassicRaceTracker:UpdatePlayerHistory(playerInfo)
     end
 end
 
+-- Applies a record to the firstToLevel slot levels[level], keeping the earliest
+-- dingedAt with name as deterministic tiebreaker. On otherwise identical records
+-- a missing classIndex is filled in, so clients holding the same record with and
+-- without class info converge on the same hash instead of mismatching forever.
+-- Returns true when the slot was replaced.
+local function mergeFTLRecord(levels, level, name, classIndex, dingedAt)
+    local existing = levels[level]
+    if existing == nil or dingedAt < existing.dingedAt
+            or (dingedAt == existing.dingedAt and name < existing.name) then
+        levels[level] = {name = name, classIndex = classIndex, dingedAt = dingedAt}
+        return true
+    end
+    if dingedAt == existing.dingedAt and name == existing.name
+            and (existing.classIndex == nil or existing.classIndex == 0)
+            and classIndex ~= nil and classIndex ~= 0 then
+        existing.classIndex = classIndex
+    end
+    return false
+end
+
 -- Updates firstToLevel (overall and per-class) and raceStartedAt for every detected player.
 function TheClassicRaceTracker:UpdatePioneers(playerInfo)
     local dingedAt = playerInfo.dingedAt
@@ -466,6 +522,9 @@ function TheClassicRaceTracker:UpdatePioneers(playerInfo)
     local level = playerInfo.level
     local classIndex = playerInfo.classIndex
 
+    -- level 1 is not a ding, and levels above 99 don't fit the 2-digit wire format
+    if level < 2 or level > 99 then return end
+
     -- track the earliest detection as race start
     if db.raceStartedAt == nil or dingedAt < db.raceStartedAt then
         db.raceStartedAt = dingedAt
@@ -473,20 +532,12 @@ function TheClassicRaceTracker:UpdatePioneers(playerInfo)
 
     -- overall (classFilter 0)
     if db.firstToLevel[0] == nil then db.firstToLevel[0] = {} end
-    local ftl0 = db.firstToLevel[0]
-    if ftl0[level] == nil or dingedAt < ftl0[level].dingedAt
-            or (dingedAt == ftl0[level].dingedAt and name < ftl0[level].name) then
-        ftl0[level] = {name = name, classIndex = classIndex, dingedAt = dingedAt}
-    end
+    mergeFTLRecord(db.firstToLevel[0], level, name, classIndex, dingedAt)
 
     -- per-class
     if classIndex ~= nil and classIndex ~= 0 then
         if db.firstToLevel[classIndex] == nil then db.firstToLevel[classIndex] = {} end
-        local ftlC = db.firstToLevel[classIndex]
-        if ftlC[level] == nil or dingedAt < ftlC[level].dingedAt
-                or (dingedAt == ftlC[level].dingedAt and name < ftlC[level].name) then
-            ftlC[level] = {name = name, classIndex = classIndex, dingedAt = dingedAt}
-        end
+        mergeFTLRecord(db.firstToLevel[classIndex], level, name, classIndex, dingedAt)
     end
 end
 
@@ -504,11 +555,12 @@ function TheClassicRaceTracker:OnFTLSyncResult(ftldb, remoteRealmOpenedAt)
             db.firstToLevel[classFilter] = {}
         end
         for level, record in pairs(levels) do
-            local existing = db.firstToLevel[classFilter][level]
-            if existing == nil or record.dingedAt < existing.dingedAt
-                    or (record.dingedAt == existing.dingedAt and record.name < existing.name) then
-                db.firstToLevel[classFilter][level] = record
-                if db.raceStartedAt == nil or record.dingedAt < db.raceStartedAt then
+            -- only merge records that fit the wire format; remote data is untrusted
+            if type(level) == "number" and level >= 2 and level <= 99
+                    and record.name ~= nil and record.dingedAt ~= nil then
+                local merged = mergeFTLRecord(db.firstToLevel[classFilter], level,
+                        record.name, record.classIndex, record.dingedAt)
+                if merged and (db.raceStartedAt == nil or record.dingedAt < db.raceStartedAt) then
                     db.raceStartedAt = record.dingedAt
                 end
             end

--- a/src/defaultdb.lua
+++ b/src/defaultdb.lua
@@ -8,7 +8,6 @@ local TheClassicRaceDefaultDB = {
                 hide = false,
             },
             networking = true,
-            dontbump = false,
             maxLevelNotify = true,
             classTopN = 3,
             globalTopN = 5,

--- a/src/defaultdb.lua
+++ b/src/defaultdb.lua
@@ -34,7 +34,9 @@ local TheClassicRaceDefaultDB = {
             },
         },
         -- Pioneers: first player to reach each level
-        -- raceStartedAt: earliest dingedAt ever seen; used as race-start reference for time display
+        -- realmOpenedAt: GetServerTime() recorded on first-ever DB init for this realm; synced to keep earliest
+        realmOpenedAt = nil,
+        -- raceStartedAt: earliest dingedAt ever seen; fallback reference when realmOpenedAt is nil
         raceStartedAt = nil,
         -- playerHistory[name] = {classIndex, levels = {[level] = dingedAt}}
         playerHistory = {},

--- a/src/defaultdb.lua
+++ b/src/defaultdb.lua
@@ -12,6 +12,7 @@ local TheClassicRaceDefaultDB = {
             maxLevelNotify = true,
             classTopN = 3,
             globalTopN = 5,
+            debug = false,
         },
         gui = {
             display = true,

--- a/src/defaultdb.lua
+++ b/src/defaultdb.lua
@@ -32,6 +32,15 @@ local TheClassicRaceDefaultDB = {
                 players = {},
             },
         },
+        -- Pioneers: first player to reach each level
+        -- raceStartedAt: earliest dingedAt ever seen; used as race-start reference for time display
+        raceStartedAt = nil,
+        -- playerHistory[name] = {classIndex, levels = {[level] = dingedAt}}
+        playerHistory = {},
+        -- firstToLevel[classFilter][level] = {name, classIndex, dingedAt}
+        -- classFilter 0 = overall, 1-11 = per class
+        firstToLevel = {},
+        pioneersMigrated = false,
     },
 }
 

--- a/src/defaultdb.lua
+++ b/src/defaultdb.lua
@@ -40,7 +40,7 @@ local TheClassicRaceDefaultDB = {
         -- playerHistory[name] = {classIndex, levels = {[level] = dingedAt}}
         playerHistory = {},
         -- firstToLevel[classFilter][level] = {name, classIndex, dingedAt}
-        -- classFilter 0 = overall, 1-11 = per class
+        -- classFilter 0 = overall, 1-12 = per class (see Config.ClassIndexes)
         firstToLevel = {},
         pioneersMigrated = false,
     },

--- a/src/dev.lua
+++ b/src/dev.lua
@@ -12,11 +12,7 @@ function TheClassicRace:slashtcr(input)
 
     --[[SCAN]]--
     if action == "scan" then
-        self.scanner:StartScan()
-
-    --[[CLASS SYNC]]--
-    elseif action == "classscan" then
-        self.classScanner:StartScan()
+        self.scanner:TriggerScan()
 
     --[[RESET]]--
     elseif action == "reset" then

--- a/src/gui/debug-frame.lua
+++ b/src/gui/debug-frame.lua
@@ -10,6 +10,9 @@ local AceGUI = LibStub("AceGUI-3.0")
 -- WoW API
 local GetServerTime, math = _G.GetServerTime, _G.math
 
+local GRAY = "|cff888888"
+local YELLOW = "|cffffff00"
+
 local function formatAge(timestamp)
     if not timestamp then return "never" end
     local diff = GetServerTime() - timestamp
@@ -30,13 +33,23 @@ setmetatable(TheClassicRaceDebugFrame, {
     __call = function(cls, ...) return cls.new(...) end,
 })
 
-function TheClassicRaceDebugFrame.new(Config, Core, DB)
+function TheClassicRaceDebugFrame.new(Config, Core, DB, EventBus)
     local self = setmetatable({}, TheClassicRaceDebugFrame)
     self.Config = Config
     self.Core = Core
     self.DB = DB
+    self.EventBus = EventBus
     self.frame = nil
     self.scroll = nil
+
+    local _self = self
+    EventBus:RegisterCallback(Config.Events.MsgStats, self, function()
+        _self:Render()
+    end)
+    EventBus:RegisterCallback(Config.Events.BuddyUpdate, self, function()
+        _self:Render()
+    end)
+
     return self
 end
 
@@ -60,9 +73,9 @@ function TheClassicRaceDebugFrame:Show()
     local _self = self
 
     local frame = AceGUI:Create("Window")
-    frame:SetTitle("TCR Buddies")
+    frame:SetTitle("TCR Debug")
     frame:SetWidth(320)
-    frame:SetHeight(420)
+    frame:SetHeight(480)
     frame:SetLayout("Flow")
     frame:SetCallback("OnClose", function(widget)
         widget:Release()
@@ -72,7 +85,7 @@ function TheClassicRaceDebugFrame:Show()
     self.frame = frame
 
     local pingBtn = AceGUI:Create("Button")
-    pingBtn:SetText("Ping Now")
+    pingBtn:SetText("Ping Buddies")
     pingBtn:SetWidth(150)
     pingBtn:SetCallback("OnClick", function()
         TheClassicRace.Sync:SendBuddyPings()
@@ -88,6 +101,15 @@ function TheClassicRaceDebugFrame:Show()
         _self:Render()
     end)
     frame:AddChild(clearBtn)
+
+    local resetStatsBtn = AceGUI:Create("Button")
+    resetStatsBtn:SetText("Reset Stats")
+    resetStatsBtn:SetWidth(150)
+    resetStatsBtn:SetCallback("OnClick", function()
+        TheClassicRace.MsgStats = { send = {}, recv = {} }
+        _self:Render()
+    end)
+    frame:AddChild(resetStatsBtn)
 
     local scrolltainer = AceGUI:Create("SimpleGroup")
     scrolltainer:SetLayout("Fill")
@@ -109,6 +131,60 @@ function TheClassicRaceDebugFrame:Render()
     if not self.scroll then return end
     self.scroll:ReleaseChildren()
 
+    self:RenderMsgStats()
+    self:RenderBuddies()
+
+    self.scroll:DoLayout()
+end
+
+function TheClassicRaceDebugFrame:RenderMsgStats()
+    local stats = TheClassicRace.MsgStats
+    if not stats then return end
+
+    local statsHeader = AceGUI:Create("Label")
+    statsHeader:SetFullWidth(true)
+    statsHeader:SetText(YELLOW .. "Messages|r")
+    self.scroll:AddChild(statsHeader)
+
+    -- collect union of all event types seen in send or recv
+    local allEvents = {}
+    local seen = {}
+    for event, _ in pairs(stats.send) do
+        if not seen[event] then seen[event] = true; allEvents[#allEvents + 1] = event end
+    end
+    for event, _ in pairs(stats.recv) do
+        if not seen[event] then seen[event] = true; allEvents[#allEvents + 1] = event end
+    end
+    table.sort(allEvents)
+
+    if #allEvents == 0 then
+        local none = AceGUI:Create("Label")
+        none:SetFullWidth(true)
+        none:SetText(GRAY .. "  no messages yet|r")
+        self.scroll:AddChild(none)
+    else
+        local header = AceGUI:Create("Label")
+        header:SetFullWidth(true)
+        header:SetText(GRAY .. "  type            send  recv|r")
+        self.scroll:AddChild(header)
+
+        for _, event in ipairs(allEvents) do
+            local s = stats.send[event] or 0
+            local r = stats.recv[event] or 0
+            local label = AceGUI:Create("Label")
+            label:SetFullWidth(true)
+            label:SetText(string.format("  %-16s %4d  %4d", event, s, r))
+            self.scroll:AddChild(label)
+        end
+    end
+
+    local spacer = AceGUI:Create("Label")
+    spacer:SetFullWidth(true)
+    spacer:SetText(" ")
+    self.scroll:AddChild(spacer)
+end
+
+function TheClassicRaceDebugFrame:RenderBuddies()
     local buddies = self.DB.factionrealm.buddies
 
     local list = {}
@@ -119,17 +195,15 @@ function TheClassicRaceDebugFrame:Render()
         return (a.lastSeen or 0) > (b.lastSeen or 0)
     end)
 
-    local header = AceGUI:Create("Label")
-    header:SetFullWidth(true)
-    header:SetText("|cffffff00Buddies: " .. #list .. "|r")
-    self.scroll:AddChild(header)
+    local buddyHeader = AceGUI:Create("Label")
+    buddyHeader:SetFullWidth(true)
+    buddyHeader:SetText(YELLOW .. "Buddies: " .. #list .. "|r")
+    self.scroll:AddChild(buddyHeader)
 
     for _, buddy in ipairs(list) do
         local label = AceGUI:Create("Label")
         label:SetFullWidth(true)
-        label:SetText(buddy.name .. "  |cff888888" .. formatAge(buddy.lastSeen) .. "|r")
+        label:SetText(buddy.name .. "  " .. GRAY .. formatAge(buddy.lastSeen) .. "|r")
         self.scroll:AddChild(label)
     end
-
-    self.scroll:DoLayout()
 end

--- a/src/gui/debug-frame.lua
+++ b/src/gui/debug-frame.lua
@@ -10,8 +10,29 @@ local AceGUI = LibStub("AceGUI-3.0")
 -- WoW API
 local GetServerTime, math = _G.GetServerTime, _G.math
 
-local GRAY = "|cff888888"
+local WHITE = "|cffffffff"
 local YELLOW = "|cffffff00"
+local GRAY  = "|cff888888"
+local DIM   = "|cff555555"
+
+local COL_EVENT = 165
+local COL_COUNT = 57
+
+-- Human-readable names for network event codes
+local EVENT_NAMES = {
+    PINFOB    = "PlayerInfoBatch",
+    REQSYNC   = "RequestSync",
+    OFFERSYNC = "OfferSync",
+    STARTSYNC = "StartSync",
+    SYNC      = "SyncPayload",
+    DATAAVAIL = "DataAvail",
+    DATAREQ   = "DataRequest",
+    GUILDSYNC = "GuildSync",
+    GUILDOFFR = "GuildOffer",
+    BPING     = "BuddyPing",
+    BPONG     = "BuddyPong",
+    FTLSYNC   = "FTLSync",
+}
 
 local function formatAge(timestamp)
     if not timestamp then return "never" end
@@ -43,12 +64,8 @@ function TheClassicRaceDebugFrame.new(Config, Core, DB, EventBus)
     self.scroll = nil
 
     local _self = self
-    EventBus:RegisterCallback(Config.Events.MsgStats, self, function()
-        _self:Render()
-    end)
-    EventBus:RegisterCallback(Config.Events.BuddyUpdate, self, function()
-        _self:Render()
-    end)
+    EventBus:RegisterCallback(Config.Events.MsgStats, self, function() _self:Render() end)
+    EventBus:RegisterCallback(Config.Events.BuddyUpdate, self, function() _self:Render() end)
 
     return self
 end
@@ -94,7 +111,7 @@ function TheClassicRaceDebugFrame:Show()
     frame:AddChild(pingBtn)
 
     local clearBtn = AceGUI:Create("Button")
-    clearBtn:SetText("Clear List")
+    clearBtn:SetText("Clear Buddies")
     clearBtn:SetWidth(150)
     clearBtn:SetCallback("OnClick", function()
         _self.DB.factionrealm.buddies = {}
@@ -127,13 +144,45 @@ function TheClassicRaceDebugFrame:Show()
     self:Render()
 end
 
+-- Adds a 3-column table row to the scroll container.
+function TheClassicRaceDebugFrame:AddRow(col1, col2, col3, col1Color, col2Color, col3Color)
+    local nameLabel = AceGUI:Create("Label")
+    nameLabel:SetWidth(COL_EVENT)
+    nameLabel:SetText((col1Color or WHITE) .. col1 .. "|r")
+    self.scroll:AddChild(nameLabel)
+
+    local sentLabel = AceGUI:Create("Label")
+    sentLabel:SetWidth(COL_COUNT)
+    sentLabel:SetText((col2Color or WHITE) .. col2 .. "|r")
+    sentLabel:SetJustifyH("RIGHT")
+    self.scroll:AddChild(sentLabel)
+
+    local recvLabel = AceGUI:Create("Label")
+    recvLabel:SetWidth(COL_COUNT)
+    recvLabel:SetText((col3Color or WHITE) .. col3 .. "|r")
+    recvLabel:SetJustifyH("RIGHT")
+    self.scroll:AddChild(recvLabel)
+end
+
+function TheClassicRaceDebugFrame:AddSeparator()
+    local sep = AceGUI:Create("Label")
+    sep:SetFullWidth(true)
+    sep:SetText(DIM .. string.rep("\xe2\x94\x80", 36) .. "|r")
+    self.scroll:AddChild(sep)
+end
+
+function TheClassicRaceDebugFrame:AddSpacer()
+    local spacer = AceGUI:Create("Label")
+    spacer:SetFullWidth(true)
+    spacer:SetText(" ")
+    self.scroll:AddChild(spacer)
+end
+
 function TheClassicRaceDebugFrame:Render()
     if not self.scroll then return end
     self.scroll:ReleaseChildren()
-
     self:RenderMsgStats()
     self:RenderBuddies()
-
     self.scroll:DoLayout()
 end
 
@@ -141,47 +190,44 @@ function TheClassicRaceDebugFrame:RenderMsgStats()
     local stats = TheClassicRace.MsgStats
     if not stats then return end
 
-    local statsHeader = AceGUI:Create("Label")
-    statsHeader:SetFullWidth(true)
-    statsHeader:SetText(YELLOW .. "Messages|r")
-    self.scroll:AddChild(statsHeader)
-
-    -- collect union of all event types seen in send or recv
+    -- collect union of all event types seen
     local allEvents = {}
     local seen = {}
-    for event, _ in pairs(stats.send) do
+    for event in pairs(stats.send) do
         if not seen[event] then seen[event] = true; allEvents[#allEvents + 1] = event end
     end
-    for event, _ in pairs(stats.recv) do
+    for event in pairs(stats.recv) do
         if not seen[event] then seen[event] = true; allEvents[#allEvents + 1] = event end
     end
     table.sort(allEvents)
 
+    -- header row
+    self:AddRow("Message Type", "Sent", "Recv", YELLOW, YELLOW, YELLOW)
+    self:AddSeparator()
+
     if #allEvents == 0 then
         local none = AceGUI:Create("Label")
         none:SetFullWidth(true)
-        none:SetText(GRAY .. "  no messages yet|r")
+        none:SetText(GRAY .. "no messages yet|r")
         self.scroll:AddChild(none)
     else
-        local header = AceGUI:Create("Label")
-        header:SetFullWidth(true)
-        header:SetText(GRAY .. "  type            send  recv|r")
-        self.scroll:AddChild(header)
-
+        local totalSend, totalRecv = 0, 0
         for _, event in ipairs(allEvents) do
             local s = stats.send[event] or 0
             local r = stats.recv[event] or 0
-            local label = AceGUI:Create("Label")
-            label:SetFullWidth(true)
-            label:SetText(string.format("  %-16s %4d  %4d", event, s, r))
-            self.scroll:AddChild(label)
+            totalSend = totalSend + s
+            totalRecv = totalRecv + r
+            local name = EVENT_NAMES[event] or event
+            local sColor = s > 0 and WHITE or GRAY
+            local rColor = r > 0 and WHITE or GRAY
+            self:AddRow(name, tostring(s), tostring(r), WHITE, sColor, rColor)
         end
+
+        self:AddSeparator()
+        self:AddRow("Total", tostring(totalSend), tostring(totalRecv), YELLOW, YELLOW, YELLOW)
     end
 
-    local spacer = AceGUI:Create("Label")
-    spacer:SetFullWidth(true)
-    spacer:SetText(" ")
-    self.scroll:AddChild(spacer)
+    self:AddSpacer()
 end
 
 function TheClassicRaceDebugFrame:RenderBuddies()
@@ -200,10 +246,12 @@ function TheClassicRaceDebugFrame:RenderBuddies()
     buddyHeader:SetText(YELLOW .. "Buddies: " .. #list .. "|r")
     self.scroll:AddChild(buddyHeader)
 
+    self:AddSeparator()
+
     for _, buddy in ipairs(list) do
         local label = AceGUI:Create("Label")
         label:SetFullWidth(true)
-        label:SetText(buddy.name .. "  " .. GRAY .. formatAge(buddy.lastSeen) .. "|r")
+        label:SetText(WHITE .. buddy.name .. "  " .. GRAY .. formatAge(buddy.lastSeen) .. "|r")
         self.scroll:AddChild(label)
     end
 end

--- a/src/gui/debug-frame.lua
+++ b/src/gui/debug-frame.lua
@@ -13,6 +13,11 @@ local GetServerTime, math = _G.GetServerTime, _G.math
 local WHITE  = "|cffffffff"
 local YELLOW = "|cffffff00"
 local GRAY   = "|cff888888"
+local GREEN  = "|cff44ff44"
+local ORANGE = "|cffffaa00"
+
+-- Short label for a class index used in hash log display
+local CLASS_SHORT = { [0]="G","Wa","Pa","Hu","Ro","Pr","DK","Sh","Ma","Wl","Mo","Dr","DH" }
 
 -- Relative column widths — must sum to < 1.0 so the leftover gap never
 -- fits the next row's first widget, guaranteeing correct line breaks in
@@ -185,6 +190,7 @@ function TheClassicRaceDebugFrame:Render()
     if not self.scroll then return end
     self.scroll:ReleaseChildren()
     self:RenderMsgStats()
+    self:RenderHashLog()
     self:RenderBuddies()
     self.scroll:DoLayout()
 end
@@ -226,6 +232,45 @@ function TheClassicRaceDebugFrame:RenderMsgStats()
         end
         self:AddSeparator()
         self:AddRow("Total", tostring(totalSend), tostring(totalRecv), YELLOW, YELLOW, YELLOW)
+    end
+
+    self:AddSpacer()
+end
+
+function TheClassicRaceDebugFrame:RenderHashLog()
+    local log = TheClassicRace.HashLog
+    if not log or #log == 0 then return end
+
+    local header = AceGUI:Create("Label")
+    header:SetFullWidth(true)
+    header:SetText(YELLOW .. "Hash Mismatches|r")
+    self.scroll:AddChild(header)
+
+    self:AddSeparator()
+
+    for _, entry in ipairs(log) do
+        local t = entry.time
+        local timeStr = string.format("%02d:%02d:%02d",
+            math.floor(t / 3600) % 24,
+            math.floor(t / 60) % 60,
+            t % 60)
+
+        local arrow = entry.direction == ">" and GREEN .. ">|r" or ORANGE .. "<|r"
+
+        local parts = {}
+        table.sort(entry.classes)
+        for _, ci in ipairs(entry.classes) do
+            parts[#parts + 1] = CLASS_SHORT[ci] or tostring(ci)
+        end
+        if entry.ftl then parts[#parts + 1] = "FTL" end
+        local clsStr = #parts > 0 and table.concat(parts, ",") or "?"
+
+        local label = AceGUI:Create("Label")
+        label:SetFullWidth(true)
+        label:SetText(GRAY .. timeStr .. "|r " .. arrow .. " "
+                .. WHITE .. entry.sender .. "|r "
+                .. GRAY .. "[" .. clsStr .. "]|r")
+        self.scroll:AddChild(label)
     end
 
     self:AddSpacer()

--- a/src/gui/debug-frame.lua
+++ b/src/gui/debug-frame.lua
@@ -10,13 +10,15 @@ local AceGUI = LibStub("AceGUI-3.0")
 -- WoW API
 local GetServerTime, math = _G.GetServerTime, _G.math
 
-local WHITE = "|cffffffff"
+local WHITE  = "|cffffffff"
 local YELLOW = "|cffffff00"
-local GRAY  = "|cff888888"
-local DIM   = "|cff555555"
+local GRAY   = "|cff888888"
 
-local COL_EVENT = 165
-local COL_COUNT = 57
+-- Relative column widths — must sum to < 1.0 so the leftover gap never
+-- fits the next row's first widget, guaranteeing correct line breaks in
+-- AceGUI's Flow layout.
+local REL_EVENT = 0.62
+local REL_COUNT = 0.18   -- two count columns * 0.18 = 0.36 → total 0.98
 
 -- Human-readable names for network event codes
 local EVENT_NAMES = {
@@ -144,21 +146,22 @@ function TheClassicRaceDebugFrame:Show()
     self:Render()
 end
 
--- Adds a 3-column table row to the scroll container.
+-- Three-column row using relative widths so the columns always fill the
+-- container and the Flow layout never places the next row on the same line.
 function TheClassicRaceDebugFrame:AddRow(col1, col2, col3, col1Color, col2Color, col3Color)
     local nameLabel = AceGUI:Create("Label")
-    nameLabel:SetWidth(COL_EVENT)
+    nameLabel:SetRelativeWidth(REL_EVENT)
     nameLabel:SetText((col1Color or WHITE) .. col1 .. "|r")
     self.scroll:AddChild(nameLabel)
 
     local sentLabel = AceGUI:Create("Label")
-    sentLabel:SetWidth(COL_COUNT)
+    sentLabel:SetRelativeWidth(REL_COUNT)
     sentLabel:SetText((col2Color or WHITE) .. col2 .. "|r")
     sentLabel:SetJustifyH("RIGHT")
     self.scroll:AddChild(sentLabel)
 
     local recvLabel = AceGUI:Create("Label")
-    recvLabel:SetWidth(COL_COUNT)
+    recvLabel:SetRelativeWidth(REL_COUNT)
     recvLabel:SetText((col3Color or WHITE) .. col3 .. "|r")
     recvLabel:SetJustifyH("RIGHT")
     self.scroll:AddChild(recvLabel)
@@ -167,7 +170,7 @@ end
 function TheClassicRaceDebugFrame:AddSeparator()
     local sep = AceGUI:Create("Label")
     sep:SetFullWidth(true)
-    sep:SetText(DIM .. string.rep("\xe2\x94\x80", 36) .. "|r")
+    sep:SetText(GRAY .. string.rep("-", 32) .. "|r")
     self.scroll:AddChild(sep)
 end
 
@@ -190,7 +193,6 @@ function TheClassicRaceDebugFrame:RenderMsgStats()
     local stats = TheClassicRace.MsgStats
     if not stats then return end
 
-    -- collect union of all event types seen
     local allEvents = {}
     local seen = {}
     for event in pairs(stats.send) do
@@ -201,8 +203,7 @@ function TheClassicRaceDebugFrame:RenderMsgStats()
     end
     table.sort(allEvents)
 
-    -- header row
-    self:AddRow("Message Type", "Sent", "Recv", YELLOW, YELLOW, YELLOW)
+    self:AddRow("Message Type", "Snt", "Rcv", YELLOW, YELLOW, YELLOW)
     self:AddSeparator()
 
     if #allEvents == 0 then
@@ -218,11 +219,11 @@ function TheClassicRaceDebugFrame:RenderMsgStats()
             totalSend = totalSend + s
             totalRecv = totalRecv + r
             local name = EVENT_NAMES[event] or event
-            local sColor = s > 0 and WHITE or GRAY
-            local rColor = r > 0 and WHITE or GRAY
-            self:AddRow(name, tostring(s), tostring(r), WHITE, sColor, rColor)
+            self:AddRow(name, tostring(s), tostring(r),
+                WHITE,
+                s > 0 and WHITE or GRAY,
+                r > 0 and WHITE or GRAY)
         end
-
         self:AddSeparator()
         self:AddRow("Total", tostring(totalSend), tostring(totalRecv), YELLOW, YELLOW, YELLOW)
     end

--- a/src/gui/debug-frame.lua
+++ b/src/gui/debug-frame.lua
@@ -40,6 +40,15 @@ function TheClassicRaceDebugFrame.new(Config, Core, DB)
     return self
 end
 
+function TheClassicRaceDebugFrame:Hide()
+    if self.frame then
+        self.frame:Hide()
+        self.frame:Release()
+        self.frame = nil
+        self.scroll = nil
+    end
+end
+
 function TheClassicRaceDebugFrame:Show()
     if self.frame then
         self.frame:Hide()

--- a/src/gui/pioneers-frame.lua
+++ b/src/gui/pioneers-frame.lua
@@ -1,0 +1,106 @@
+-- Libs
+local LibStub = _G.LibStub
+
+-- Addon global
+local TheClassicRace = _G.TheClassicRace
+
+-- deps
+local AceGUI = LibStub("AceGUI-3.0")
+
+-- WoW API
+local math = _G.math
+
+local GRAY = "|cFF888888"
+
+local function formatTimeSince(elapsed)
+    elapsed = math.floor(math.max(0, elapsed))
+    local s = elapsed % 60
+    local m = math.floor(elapsed / 60) % 60
+    local h = math.floor(elapsed / 3600) % 24
+    local d = math.floor(elapsed / 86400)
+    return string.format("%02d:%02d:%02d:%02d", d, h, m, s)
+end
+
+--[[
+PioneersView renders the "Pioneers" tab inside the main status frame.
+It shows, for each level from MaxLevel down to 2, which player was first detected
+at that level (overall or filtered by class), along with how long after the race
+start that happened.
+]]--
+---@class TheClassicRacePioneersView
+---@field Config TheClassicRaceConfig
+---@field Core TheClassicRaceCore
+---@field DB table
+local TheClassicRacePioneersView = {}
+TheClassicRacePioneersView.__index = TheClassicRacePioneersView
+TheClassicRace.PioneersView = TheClassicRacePioneersView
+setmetatable(TheClassicRacePioneersView, {
+    __call = function(cls, ...)
+        return cls.new(...)
+    end,
+})
+
+function TheClassicRacePioneersView.new(Config, Core, DB)
+    local self = setmetatable({}, TheClassicRacePioneersView)
+    self.Config = Config
+    self.Core = Core
+    self.DB = DB
+    return self
+end
+
+function TheClassicRacePioneersView:Render(container, classIndex)
+    container:ReleaseChildren()
+
+    local WHITE = TheClassicRace.Colors.WHITE
+    local ftl = self.DB.factionrealm.firstToLevel or {}
+    local raceStartedAt = self.DB.factionrealm.raceStartedAt
+    local levels = ftl[classIndex]
+
+    local scrolltainer = AceGUI:Create("SimpleGroup")
+    scrolltainer:SetLayout("Fill")
+    scrolltainer:SetFullWidth(true)
+    scrolltainer:SetFullHeight(true)
+    container:AddChild(scrolltainer)
+
+    local scroll = AceGUI:Create("ScrollFrame")
+    scroll:SetLayout("Flow")
+    scroll:SetFullWidth(true)
+    scroll:SetFullHeight(true)
+    scrolltainer:AddChild(scroll)
+
+    -- keep scrollbar clear of resize grip
+    scroll.scrollbar:ClearAllPoints()
+    scroll.scrollbar:SetPoint("TOPLEFT", scroll.scrollframe, "TOPRIGHT", 4, -16)
+    scroll.scrollbar:SetPoint("BOTTOMLEFT", scroll.scrollframe, "BOTTOMRIGHT", 4, 32)
+
+    local hasAnyData = false
+
+    for lvl = self.Config.MaxLevel, 2, -1 do
+        local label = AceGUI:Create("Label")
+        label:SetFullWidth(true)
+
+        local record = levels and levels[lvl]
+        if record then
+            hasAnyData = true
+            local elapsed = raceStartedAt and (record.dingedAt - raceStartedAt) or 0
+            local timeStr = formatTimeSince(elapsed)
+            local playerClass = self.Core:ClassByIndex(record.classIndex)
+            local color = TheClassicRace.Colors[playerClass] or WHITE
+            label:SetText(timeStr .. " Lvl " .. string.format("%2d", lvl) .. ": " .. color .. record.name .. "|r")
+        else
+            label:SetText(GRAY .. "           Lvl " .. string.format("%2d", lvl) .. ": no data|r")
+        end
+
+        scroll:AddChild(label)
+    end
+
+    if not hasAnyData then
+        -- insert a hint at the very top (already added all rows, prepend a note via first child)
+        local hint = AceGUI:Create("Label")
+        hint:SetFullWidth(true)
+        hint:SetText(GRAY .. "No pioneer data yet — keep scanning!|r")
+        scroll:AddChild(hint)
+    end
+
+    scroll:DoLayout()
+end

--- a/src/gui/pioneers-frame.lua
+++ b/src/gui/pioneers-frame.lua
@@ -53,7 +53,9 @@ function TheClassicRacePioneersView:Render(container, classIndex)
 
     local WHITE = TheClassicRace.Colors.WHITE
     local ftl = self.DB.factionrealm.firstToLevel or {}
-    local raceStartedAt = self.DB.factionrealm.raceStartedAt
+    -- Use realm-opened timestamp as the fixed race-start reference.
+    -- Fall back to raceStartedAt (earliest player detection) if realmOpenedAt is not yet synced.
+    local refTime = self.DB.factionrealm.realmOpenedAt or self.DB.factionrealm.raceStartedAt
     local levels = ftl[classIndex]
 
     local scrolltainer = AceGUI:Create("SimpleGroup")
@@ -82,7 +84,7 @@ function TheClassicRacePioneersView:Render(container, classIndex)
         local record = levels and levels[lvl]
         if record then
             hasAnyData = true
-            local elapsed = raceStartedAt and (record.dingedAt - raceStartedAt) or 0
+            local elapsed = refTime and (record.dingedAt - refTime) or 0
             local timeStr = formatTimeSince(elapsed)
             local playerClass = self.Core:ClassByIndex(record.classIndex)
             local color = TheClassicRace.Colors[playerClass] or WHITE

--- a/src/gui/status-frame.lua
+++ b/src/gui/status-frame.lua
@@ -47,6 +47,8 @@ function TheClassicRaceStatusFrame.new(Config, Core, DB, EventBus)
     self.contentframe = nil
     self.refreshPending = false
 
+    self.players = self.DB.factionrealm.leaderboard[self.classIndex].players
+
     self.pioneersView = TheClassicRace.PioneersView(Config, Core, DB)
 
     self:OnRefreshGUI()
@@ -124,6 +126,7 @@ function TheClassicRaceStatusFrame:Show()
     TheClassicRaceStatusFrame.FixResizeStatusUpdates(frame)
     frame:DoLayout()
 
+    self.players = self.DB.factionrealm.leaderboard[self.classIndex].players
     self.frame = frame
 
     self:RenderLeftIcon()

--- a/src/gui/status-frame.lua
+++ b/src/gui/status-frame.lua
@@ -39,9 +39,13 @@ function TheClassicRaceStatusFrame.new(Config, Core, DB, EventBus)
     EventBus:RegisterCallback(self.Config.Events.RefreshGUI, self, self.OnRefreshGUI)
 
     self.classIndex = 0
+    self.view = "leaderboard"   -- "leaderboard" or "pioneers"
     self.frame = nil
     self.tabicons = nil
+    self.lefticons = nil
     self.contentframe = nil
+
+    self.pioneersView = TheClassicRace.PioneersView(Config, Core, DB)
 
     self:OnRefreshGUI()
 
@@ -60,6 +64,7 @@ function TheClassicRaceStatusFrame:Refresh()
     self.players = self.DB.factionrealm.leaderboard[self.classIndex].players
 
     if self.frame ~= nil and self.contentframe ~= nil then
+        self:RenderLeftIcon()
         self:RenderTabicons()
         self:Render()
     end
@@ -95,12 +100,19 @@ function TheClassicRaceStatusFrame:Show()
             _self.tabicons:Release()
             _self.tabicons = nil
         end
+
+        -- release left icon
+        if _self.lefticons then
+            _self.lefticons:Release()
+            _self.lefticons = nil
+        end
     end)
     TheClassicRaceStatusFrame.FixResizeStatusUpdates(frame)
     frame:DoLayout()
 
     self.frame = frame
 
+    self:RenderLeftIcon()
     self:RenderTabicons()
     self:Render()
 end
@@ -120,6 +132,43 @@ function TheClassicRaceStatusFrame.FixResizeStatusUpdates(frame)
             status.left = frame.frame:GetLeft()
         end)
     end
+end
+
+-- Left-side icon that toggles between the leaderboard and pioneers views.
+function TheClassicRaceStatusFrame:RenderLeftIcon()
+    if self.lefticons then
+        self.lefticons:Release()
+    end
+
+    local lefticons = AceGUI:Create("SimpleGroup")
+    lefticons.frame:SetFrameStrata("LOW")
+    lefticons:SetLayout("Flow")
+    lefticons:SetWidth(20)
+    lefticons:SetFullWidth(false)
+    lefticons.frame:Show()
+
+    local icon = AceGUI:Create("Icon")
+    icon:SetCallback("OnClick", function()
+        self.view = (self.view == "pioneers") and "leaderboard" or "pioneers"
+        self:Refresh()
+    end)
+    icon:SetLabel(nil)
+    icon:SetImage("Interface\\Icons\\Achievement_GuildPerk_FastTrack")
+    icon:SetImageSize(20, 20)
+    icon:SetWidth(20)
+    icon:SetHeight(20)
+    -- dim when leaderboard is active; full brightness when pioneers is active
+    if self.view ~= "pioneers" then
+        icon.image:SetVertexColor(0.8, 0.8, 0.8, 0.8)
+    end
+    lefticons:AddChild(icon)
+
+    lefticons:SetHeight(22)
+    lefticons:ClearAllPoints()
+    lefticons.frame:SetPoint("TOPRIGHT", self.frame.frame, "TOPLEFT")
+    lefticons.frame:Show()
+
+    self.lefticons = lefticons
 end
 
 function TheClassicRaceStatusFrame:RenderTabicons()
@@ -199,6 +248,16 @@ function TheClassicRaceStatusFrame:Render()
     end)
     self.frame:AddChild(frame)
 
+    if self.view == "pioneers" then
+        self.pioneersView:Render(frame, self.classIndex)
+    else
+        self:RenderLeaderboard(frame)
+    end
+
+    self.contentframe = frame
+end
+
+function TheClassicRaceStatusFrame:RenderLeaderboard(frame)
     -- display the leader
     if #self.players > 0 then
         local leader = self.players[1]
@@ -280,6 +339,4 @@ function TheClassicRaceStatusFrame:Render()
 
     -- trigger layout update to fix blank first row
     scroll:DoLayout()
-
-    self.contentframe = frame
 end

--- a/src/gui/status-frame.lua
+++ b/src/gui/status-frame.lua
@@ -9,6 +9,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 
 -- WoW API
 local GameFontNormalLarge, CLASS_ICON_TCOORDS = _G.GameFontNormalLarge, _G.CLASS_ICON_TCOORDS
+local C_Timer = _G.C_Timer
 
 -- colors
 local SEYELLOW = TheClassicRace.Colors.SYSTEM_EVENT_YELLOW
@@ -44,6 +45,7 @@ function TheClassicRaceStatusFrame.new(Config, Core, DB, EventBus)
     self.tabicons = nil
     self.lefticons = nil
     self.contentframe = nil
+    self.refreshPending = false
 
     self.pioneersView = TheClassicRace.PioneersView(Config, Core, DB)
 
@@ -52,12 +54,24 @@ function TheClassicRaceStatusFrame.new(Config, Core, DB, EventBus)
     return self
 end
 
+-- Coalesces rapid-fire Ding/RefreshGUI events (e.g. 50-player sync batch) into
+-- a single UI rebuild at the start of the next frame via C_Timer.After(0).
+function TheClassicRaceStatusFrame:ScheduleRefresh()
+    if self.refreshPending then return end
+    self.refreshPending = true
+    local _self = self
+    C_Timer.After(0, function()
+        _self.refreshPending = false
+        _self:Refresh()
+    end)
+end
+
 function TheClassicRaceStatusFrame:OnDing()
-    self:Refresh()
+    self:ScheduleRefresh()
 end
 
 function TheClassicRaceStatusFrame:OnRefreshGUI()
-    self:Refresh()
+    self:ScheduleRefresh()
 end
 
 function TheClassicRaceStatusFrame:Refresh()

--- a/src/main.lua
+++ b/src/main.lua
@@ -100,6 +100,9 @@ function TheClassicRace:DBMigrations()
     -- fresh DB or pre-versioning DB, reset and init ...
     if self.DB.factionrealm.dbversion == "0.0.0" then
         self:ResetDB()
+        -- Record server time as realm-opened reference on first ever login.
+        -- GetServerTime() is server-synced (UTC), not affected by client timezone.
+        self.DB.factionrealm.realmOpenedAt = GetServerTime()
         return
     end
     -- one-time migration: seed pioneer data from existing leaderboard entries
@@ -126,8 +129,13 @@ function TheClassicRace:MigratePioneerData()
 end
 
 function TheClassicRace:ResetDB()
+    -- Preserve realmOpenedAt so a manual data reset doesn't lose the realm launch timestamp.
+    local realmOpenedAt = self.DB.factionrealm.realmOpenedAt
     self.DB:ResetDB()
     self.DB.factionrealm.dbversion = self.Config.Version
+    if realmOpenedAt then
+        self.DB.factionrealm.realmOpenedAt = realmOpenedAt
+    end
     if self.Tracker then
         self.Tracker:ReinitLeaderboards()
     end

--- a/src/main.lua
+++ b/src/main.lua
@@ -49,9 +49,12 @@ function TheClassicRace:OnInitialize()
     self.Sync = TheClassicRace.Sync(self.Config, self.Core, self.DB, self.EventBus, self.Network)
     self.updater = TheClassicRace.Updater(self.Core, self.EventBus)
     self.StatusFrame = TheClassicRace.StatusFrame(self.Config, self.Core, self.DB, self.EventBus)
-    self.DebugFrame = TheClassicRace.DebugFrame(self.Config, self.Core, self.DB)
+    self.DebugFrame = TheClassicRace.DebugFrame(self.Config, self.Core, self.DB, self.EventBus)
 
     self.scanner = TheClassicRace.Scanner(self.Core, self.DB, self.EventBus)
+
+    -- message stats counters (only populated when debug mode is on)
+    TheClassicRace.MsgStats = { send = {}, recv = {} }
 
     self:DBMigrations()
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -90,6 +90,10 @@ function TheClassicRace:OnEnable()
     if self.DB.profile.gui.display then
         self.StatusFrame:Show()
     end
+
+    if self.DB.profile.options.debug then
+        self.DebugFrame:Show()
+    end
 end
 
 function TheClassicRace:DBMigrations()

--- a/src/main.lua
+++ b/src/main.lua
@@ -53,8 +53,9 @@ function TheClassicRace:OnInitialize()
 
     self.scanner = TheClassicRace.Scanner(self.Core, self.DB, self.EventBus)
 
-    -- message stats counters (only populated when debug mode is on)
+    -- message stats counters and hash mismatch log (only populated when debug mode is on)
     TheClassicRace.MsgStats = { send = {}, recv = {} }
+    TheClassicRace.HashLog = {}
 
     self:DBMigrations()
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -26,6 +26,8 @@ local LibStub = _G.LibStub
 ---       handles syncing when coming online
 ---@field StatusFrame   TheClassicRaceStatusFrame
 ---       GUI element to display the leaderboard
+---@field PioneersView  TheClassicRacePioneersView
+---       renders the Pioneers (first-to-level) tab inside the status frame
 ---@field DefaultDB     TheClassicRaceDefaultDB
 TheClassicRace = LibStub("AceAddon-3.0"):NewAddon("TheClassicRace", "AceConsole-3.0")
 
@@ -94,6 +96,28 @@ function TheClassicRace:DBMigrations()
     -- fresh DB or pre-versioning DB, reset and init ...
     if self.DB.factionrealm.dbversion == "0.0.0" then
         self:ResetDB()
+        return
+    end
+    -- one-time migration: seed pioneer data from existing leaderboard entries
+    if not self.DB.factionrealm.pioneersMigrated then
+        self:MigratePioneerData()
+        self.DB.factionrealm.pioneersMigrated = true
+    end
+end
+
+-- Populates firstToLevel and playerHistory from whatever leaderboard data already exists.
+-- Only runs once per DB (on first load after the pioneers feature is introduced).
+function TheClassicRace:MigratePioneerData()
+    for classIndex = 0, #self.Config.Classes do
+        local lb = self.DB.factionrealm.leaderboard[classIndex]
+        if lb and #lb.players > 0 then
+            for _, player in ipairs(lb.players) do
+                if player.dingedAt then
+                    self.Tracker:UpdatePioneers(player)
+                    self.Tracker:UpdatePlayerHistory(player)
+                end
+            end
+        end
     end
 end
 

--- a/src/networking/network.lua
+++ b/src/networking/network.lua
@@ -63,6 +63,14 @@ function TheClassicRaceNetwork:Init()
     self.EventBus:PublishEvent(TheClassicRace.Config.Events.NetworkReady)
 end
 
+function TheClassicRaceNetwork:TrackMessage(direction, event)
+    if not TheClassicRace.DB or not TheClassicRace.DB.profile.options.debug then return end
+    local stats = TheClassicRace.MsgStats
+    if not stats then return end
+    stats[direction][event] = (stats[direction][event] or 0) + 1
+    self.EventBus:PublishEvent(TheClassicRace.Config.Events.MsgStats)
+end
+
 function TheClassicRaceNetwork:HandleAddonMessage(...)
     local prefix, message, _, sender = ...
 
@@ -106,6 +114,7 @@ function TheClassicRaceNetwork:HandleAddonMessage(...)
         TheClassicRace:DebugPrint("Recv " .. event .. " <- " .. sender)
         debugLogPayload(event, payload)
 
+        self:TrackMessage("recv", event)
         self.EventBus:PublishEvent(event, payload, sender)
     end)
 
@@ -127,6 +136,7 @@ function TheClassicRaceNetwork:SendObject(event, object, channel, target, prio)
             " Size: " .. string.len(encoded) .. " / " .. string.len(payload))
     TheClassicRace:DebugPrint("Send " .. event .. " -> " .. channel)
     debugLogPayload(event, object)
+    self:TrackMessage("send", event)
 
     if channel == "GROUP" then
         if IsInRaid() then

--- a/src/options.lua
+++ b/src/options.lua
@@ -108,6 +108,23 @@ function TheClassicRace:RegisterOptions()
                         set = function(_, val) _self.DB.profile.options.dontbump = val end,
                         get = function() return _self.DB.profile.options.dontbump end,
                     },
+                    debugMode = {
+                        order = 33,
+                        name = "Debug Mode",
+                        desc = "Print debug output to chat and show the TCR Buddies window",
+                        descStyle = "inline",
+                        width = "full",
+                        type = "toggle",
+                        set = function(_, val)
+                            _self.DB.profile.options.debug = val
+                            if val then
+                                _self.DebugFrame:Show()
+                            else
+                                _self.DebugFrame:Hide()
+                            end
+                        end,
+                        get = function() return _self.DB.profile.options.debug end,
+                    },
                     reset = {
                         order = 50,
                         name = "Reset Data",

--- a/src/options.lua
+++ b/src/options.lua
@@ -98,16 +98,6 @@ function TheClassicRace:RegisterOptions()
                         set = function(_, val) _self.DB.profile.options.networking = val end,
                         get = function() return _self.DB.profile.options.networking end,
                     },
-                    dontBumpScan = {
-                        order = 32,
-                        name = "Always /who query",
-                        desc = "Do a /who scan every 60s even when data was synced from another player",
-                        descStyle = "inline",
-                        width = "full",
-                        type = "toggle",
-                        set = function(_, val) _self.DB.profile.options.dontbump = val end,
-                        get = function() return _self.DB.profile.options.dontbump end,
-                    },
                     debugMode = {
                         order = 33,
                         name = "Debug Mode",

--- a/src/util/chat.lua
+++ b/src/util/chat.lua
@@ -52,6 +52,24 @@ function TheClassicRace:TracePrintTable(t)
     end
 end
 
+-- Records a hash mismatch event into HashLog (newest first, capped at 12).
+-- direction: ">" we sent data to sender, "<" we received data from sender.
+-- classes: list of classIndex values that differed (0=global).
+-- ftl: boolean, whether FTL also differed.
+function TheClassicRace:AddHashLog(sender, direction, classes, ftl)
+    if not self.DB or not self.DB.profile.options.debug then return end
+    local GetServerTime = _G.GetServerTime
+    table.insert(self.HashLog, 1, {
+        time      = GetServerTime(),
+        sender    = sender,
+        direction = direction,
+        classes   = classes or {},
+        ftl       = ftl or false,
+    })
+    while #self.HashLog > 12 do table.remove(self.HashLog) end
+    self.EventBus:PublishEvent(self.Config.Events.MsgStats)
+end
+
 function TheClassicRace:PlayerChatLink(playerName, linkTitle, className)
     if linkTitle == nil then
         linkTitle = playerName

--- a/src/util/chat.lua
+++ b/src/util/chat.lua
@@ -25,7 +25,7 @@ function TheClassicRace:PPrint(message)
 end
 
 function TheClassicRace:DebugPrint(message)
-    if (self.Config.Debug == true) then
+    if self.Config.Debug or (self.DB and self.DB.profile.options.debug) then
         print("|cFF7777FFTheClassicRace Debug:|cFFFFFFFF", message)
     end
 end
@@ -37,7 +37,7 @@ function TheClassicRace:TracePrint(message)
 end
 
 function TheClassicRace:DebugPrintTable(t)
-    if (self.Config.Debug == true) then
+    if self.Config.Debug or (self.DB and self.DB.profile.options.debug) then
         print("|cFF7777FFTheClassicRace Debug:|cFFFFFFFF table...")
         print(dumpTable(t))
     end

--- a/src/util/chat.lua
+++ b/src/util/chat.lua
@@ -25,7 +25,8 @@ function TheClassicRace:PPrint(message)
 end
 
 function TheClassicRace:DebugPrint(message)
-    if self.Config.Debug or (self.DB and self.DB.profile.options.debug) then
+    local enabled = self.DB and self.DB.profile.options.debug or (not self.DB and self.Config.Debug)
+    if enabled then
         print("|cFF7777FFTheClassicRace Debug:|cFFFFFFFF", message)
     end
 end
@@ -37,7 +38,8 @@ function TheClassicRace:TracePrint(message)
 end
 
 function TheClassicRace:DebugPrintTable(t)
-    if self.Config.Debug or (self.DB and self.DB.profile.options.debug) then
+    local enabled = self.DB and self.DB.profile.options.debug or (not self.DB and self.Config.Debug)
+    if enabled then
         print("|cFF7777FFTheClassicRace Debug:|cFFFFFFFF table...")
         print(dumpTable(t))
     end

--- a/tests/leaderboard.lua
+++ b/tests/leaderboard.lua
@@ -72,6 +72,48 @@ describe("Leaderboard", function()
             local h2 = TheClassicRace.Leaderboard.ComputeHash(dbboard)
             assert.equals(h1, h2)
         end)
+
+        it("is insertion-order independent", function()
+            local players = {
+                {name = "Alice", level = 6, dingedAt = time, classIndex = 3},
+                {name = "Bob", level = 5, dingedAt = time - 10, classIndex = 1},
+                {name = "Zebra", level = 5, dingedAt = time, classIndex = 11},
+                {name = "Aardvark", level = 5, dingedAt = time, classIndex = 0},
+            }
+
+            leaderboard:ProcessPlayerInfo(players[1])
+            leaderboard:ProcessPlayerInfo(players[2])
+            leaderboard:ProcessPlayerInfo(players[3])
+            leaderboard:ProcessPlayerInfo(players[4])
+            local h1 = TheClassicRace.Leaderboard.ComputeHash(dbboard)
+
+            local dbboard2 = db.factionrealm.leaderboard[1]
+            local leaderboard2 = TheClassicRace.Leaderboard(config, dbboard2)
+            leaderboard2:ProcessPlayerInfo(players[4])
+            leaderboard2:ProcessPlayerInfo(players[3])
+            leaderboard2:ProcessPlayerInfo(players[2])
+            leaderboard2:ProcessPlayerInfo(players[1])
+            local h2 = TheClassicRace.Leaderboard.ComputeHash(dbboard2)
+
+            assert.equals(h1, h2)
+            assert.same(dbboard.players, dbboard2.players)
+        end)
+    end)
+
+    describe("SortPlayers", function()
+        it("orders legacy data canonically", function()
+            local players = {
+                {name = "Zebra", level = 5, dingedAt = time, classIndex = 11},
+                {name = "NoDing", level = 5, classIndex = 1},
+                {name = "Aardvark", level = 5, dingedAt = time, classIndex = 0},
+                {name = "Top", level = 7, dingedAt = time, classIndex = 3},
+                {name = "Early", level = 5, dingedAt = time - 10, classIndex = 1},
+            }
+            TheClassicRace.Leaderboard.SortPlayers(players)
+
+            assert.same({"Top", "Early", "Aardvark", "Zebra", "NoDing"},
+                    {players[1].name, players[2].name, players[3].name, players[4].name, players[5].name})
+        end)
     end)
 
     describe("leaderboard", function()
@@ -168,6 +210,45 @@ describe("Leaderboard", function()
             assert.equals(1, #dbboard.players)
             assert.equals(time, dbboard.players[1].dingedAt)
             assert.is_nil(changed)
+        end)
+
+        it("ignores stale lower-level info for existing player", function()
+            leaderboard:ProcessPlayerInfo({name = "Nub1", level = 25, dingedAt = time, classIndex = 11})
+            -- an earlier dingedAt at a lower level is stale data, not an update
+            local rank, changed = leaderboard:ProcessPlayerInfo({name = "Nub1", level = 20, dingedAt = time - 100, classIndex = 11})
+
+            assert.equals(1, #dbboard.players)
+            assert.equals(25, dbboard.players[1].level)
+            assert.equals(time, dbboard.players[1].dingedAt)
+            assert.is_nil(changed)
+        end)
+
+        it("fills in a previously unknown classIndex in place", function()
+            leaderboard:ProcessPlayerInfo({name = "Nub1", level = 5, dingedAt = time, classIndex = 0})
+            local rank, changed = leaderboard:ProcessPlayerInfo({name = "Nub1", level = 5, dingedAt = time, classIndex = 11})
+
+            assert.equals(1, #dbboard.players)
+            assert.equals(11, dbboard.players[1].classIndex)
+            -- not a ding, no notification
+            assert.is_nil(changed)
+        end)
+
+        it("keeps a known classIndex when a ding comes without class info", function()
+            leaderboard:ProcessPlayerInfo({name = "Nub1", level = 5, dingedAt = time, classIndex = 11})
+            leaderboard:ProcessPlayerInfo({name = "Nub1", level = 6, dingedAt = time + 10, classIndex = 0})
+
+            assert.equals(1, #dbboard.players)
+            assert.equals(6, dbboard.players[1].level)
+            assert.equals(11, dbboard.players[1].classIndex)
+        end)
+
+        it("fills in a missing dingedAt from a synced copy", function()
+            leaderboard:ProcessPlayerInfo({name = "Nub1", level = 5, classIndex = 11})
+            assert.is_nil(dbboard.players[1].dingedAt)
+
+            leaderboard:ProcessPlayerInfo({name = "Nub1", level = 5, dingedAt = time, classIndex = 11})
+            assert.equals(1, #dbboard.players)
+            assert.equals(time, dbboard.players[1].dingedAt)
         end)
 
         it("truncates on ding", function()

--- a/tests/serializer.lua
+++ b/tests/serializer.lua
@@ -119,6 +119,16 @@ describe("Serializer", function()
             assert.equals(t,       result[0][5].dingedAt)
         end)
 
+        it("deduplicates on deserialize keeping alphabetically earlier name when dingedAt is equal", function()
+            local t = 1000000000
+            local str = string.sub("0000000000" .. t, -10)
+                    .. "$"
+                    .. "000501Zebra0$"   -- dingedAt = t, name "Zebra"
+                    .. "000502Aardvark0$" -- dingedAt = t, name "Aardvark" (should win)
+            local result = DeserFTLBatch(str)
+            assert.equals("Aardvark", result[0][5].name)
+        end)
+
         it("handles single-digit class indexes correctly", function()
             local t = 1000000000
             local ftl = {

--- a/tests/serializer.lua
+++ b/tests/serializer.lua
@@ -9,6 +9,8 @@ local SerPInfo = TheClassicRace.Serializer.SerializePlayerInfo
 local DeserPInfo = TheClassicRace.Serializer.DeserializePlayerInfo
 local SerPInfoBatch = TheClassicRace.Serializer.SerializePlayerInfoBatch
 local DeserPInfoBatch = TheClassicRace.Serializer.DeserializePlayerInfoBatch
+local SerFTLBatch = TheClassicRace.Serializer.SerializeFTLBatch
+local DeserFTLBatch = TheClassicRace.Serializer.DeserializeFTLBatch
 
 function mergeConfigs(...)
     local config = {}
@@ -66,6 +68,67 @@ describe("Serializer", function()
                     AceSerializer:Serialize({nub1.name, nub1.level, nub1.dingedAt, nub1.classIndex}))
             assert.same(47,
                     string.len(AceSerializer:Serialize({nub1.name, nub1.level, nub1.dingedAt, nub1.classIndex})))
+        end)
+    end)
+
+    describe("FTLBatch", function()
+        it("empty batch serializes to empty string", function()
+            assert.equals("", SerFTLBatch({}))
+            assert.same({}, DeserFTLBatch(""))
+        end)
+
+        it("round-trips firstToLevel data", function()
+            local t = 1000000000
+            local ftl = {
+                [0] = {
+                    [15] = {name = "Alice", classIndex = 3, dingedAt = t + 100},
+                    [16] = {name = "Bob",   classIndex = 1, dingedAt = t},
+                },
+                [3] = {
+                    [15] = {name = "Alice", classIndex = 3, dingedAt = t + 100},
+                },
+            }
+
+            local str = SerFTLBatch(ftl)
+            local result = DeserFTLBatch(str)
+
+            assert.equals(t + 100, result[0][15].dingedAt)
+            assert.equals("Alice", result[0][15].name)
+            assert.equals(3,       result[0][15].classIndex)
+
+            assert.equals(t,     result[0][16].dingedAt)
+            assert.equals("Bob", result[0][16].name)
+            assert.equals(1,     result[0][16].classIndex)
+
+            assert.equals(t + 100, result[3][15].dingedAt)
+            assert.equals("Alice", result[3][15].name)
+        end)
+
+        it("deduplicates on deserialize keeping earliest dingedAt", function()
+            -- manually craft a string with two entries for (classFilter=0, level=5)
+            local t = 1000000000
+            -- format: offset$ CF(2) LV(2) CI(2) name delta $
+            local str = string.sub("0000000000" .. t, -10)
+                    .. "$"
+                    .. "000501Early0$"        -- dingedAt = t+0  (Earlier)
+                    .. "000502Late1000$"      -- dingedAt = t+1000 (Later)
+            local result = DeserFTLBatch(str)
+            -- Earlier record should win
+            assert.equals("Early", result[0][5].name)
+            assert.equals(1,       result[0][5].classIndex)
+            assert.equals(t,       result[0][5].dingedAt)
+        end)
+
+        it("handles single-digit class indexes correctly", function()
+            local t = 1000000000
+            local ftl = {
+                [0] = {[2] = {name = "Nub", classIndex = 1, dingedAt = t}},
+            }
+            local str = SerFTLBatch(ftl)
+            local result = DeserFTLBatch(str)
+            assert.equals("Nub", result[0][2].name)
+            assert.equals(1,     result[0][2].classIndex)
+            assert.equals(t,     result[0][2].dingedAt)
         end)
     end)
 

--- a/tests/serializer.lua
+++ b/tests/serializer.lua
@@ -129,6 +129,32 @@ describe("Serializer", function()
             assert.equals("Aardvark", result[0][5].name)
         end)
 
+        it("skips entries that don't fit the wire format on serialize", function()
+            local t = 1000000000
+            local ftl = {
+                [0] = {
+                    [1] = {name = "Fresh", classIndex = 1, dingedAt = t},
+                    [100] = {name = "Impossible", classIndex = 1, dingedAt = t},
+                    [10] = {name = "Racer", classIndex = 1, dingedAt = t},
+                },
+            }
+            local result = DeserFTLBatch(SerFTLBatch(ftl))
+            assert.is_nil(result[0][1])
+            assert.is_nil(result[0][100])
+            assert.equals("Racer", result[0][10].name)
+        end)
+
+        it("ignores level-1 entries on deserialize", function()
+            local t = 1000000000
+            local str = string.sub("0000000000" .. t, -10)
+                    .. "$"
+                    .. "000101Fresh0$"   -- level 1 entry, invalid
+                    .. "000501Racer0$"   -- level 5 entry, valid
+            local result = DeserFTLBatch(str)
+            assert.is_nil(result[0][1])
+            assert.equals("Racer", result[0][5].name)
+        end)
+
         it("handles single-digit class indexes correctly", function()
             local t = 1000000000
             local ftl = {

--- a/tests/stubs/chatinfo.lua
+++ b/tests/stubs/chatinfo.lua
@@ -1,3 +1,6 @@
+-- Enum table is required by newer ChatThrottleLib versions
+_G.Enum = _G.Enum or {}
+
 _G.C_ChatInfo = {}
 _G.C_ChatInfo.RegisterAddonMessagePrefix = function()
 end

--- a/tests/sync.lua
+++ b/tests/sync.lua
@@ -19,6 +19,9 @@ describe("Sync", function()
 
     local AdvanceClock
 
+    -- shorthands for the hashes of our (empty) DB
+    local myGlobalHash, myClassHash, myFTLHash, myFullHash
+
     before_each(function()
         -- easier to only test channel
         _G.SetIsInGuild(false)
@@ -39,6 +42,11 @@ describe("Sync", function()
         eventbus = TheClassicRace.EventBus()
         network = {SendObject = function() end}
         sync = TheClassicRace.Sync(TheClassicRace.Config, core, db, eventbus, network)
+
+        myGlobalHash = TheClassicRace.Leaderboard.ComputeHash(db.factionrealm.leaderboard[0])
+        myClassHash = TheClassicRace.Leaderboard.ComputeHash(db.factionrealm.leaderboard[11])
+        myFTLHash = TheClassicRace.Sync.ComputeFTLHash(db, TheClassicRace.Config)
+        myFullHash = TheClassicRace.Sync.ComputeFullHash(db, TheClassicRace.Config)
     end)
 
     after_each(function()
@@ -51,7 +59,8 @@ describe("Sync", function()
 
         sync:InitSync()
 
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.RequestSync, 11, "CHANNEL")
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.RequestSync,
+                {11, myGlobalHash, myClassHash, myFTLHash}, "YELL")
         assert.spy(networkSpy).called_at_most(1)
         networkSpy:clear()
 
@@ -61,25 +70,24 @@ describe("Sync", function()
         assert.equals(true, sync.isReady)
     end)
 
-    it("can request sync", function()
+    it("can request sync, announces to guild too", function()
         local networkSpy = spy.on(network, "SendObject")
 
         _G.SetIsInGuild(true)
 
         sync:InitSync()
 
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.RequestSync, 11, "CHANNEL")
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.RequestSync, 11, "GUILD")
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.RequestSync,
+                {11, myGlobalHash, myClassHash, myFTLHash}, "YELL")
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.GuildSync,
+                {11, myFullHash, core:LoginTime(), myFTLHash}, "GUILD")
         assert.spy(networkSpy).called_at_most(2)
     end)
 
-    it("can init and start sync with partner", function()
+    it("can init and start sync with partner that offers no hashes (old client)", function()
         local networkSpy = spy.on(network, "SendObject")
 
         sync:InitSync()
-
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.RequestSync, 11, "CHANNEL")
-        assert.spy(networkSpy).called_at_most(1)
         networkSpy:clear()
 
         eventbus:PublishEvent(NetEvents.OfferSync, {11, nil}, "Dude")
@@ -87,22 +95,56 @@ describe("Sync", function()
         -- advance our clock so the sync happens
         AdvanceClock(TheClassicRace.Config.RequestSyncWait)
 
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync, 11, "WHISPER", "Dude")
+        -- no hashes known -> sends global + class leaderboards and FTL data
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync,
+                {11, myGlobalHash, myClassHash, myFTLHash}, "WHISPER", "Dude")
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Dude")
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Dude")
-        assert.spy(networkSpy).called_at_most(3)
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.FTLSync, {""}, "WHISPER", "Dude")
+        assert.spy(networkSpy).called_at_most(4)
+    end)
+
+    it("skips syncing entirely when partner hashes all match", function()
+        local networkSpy = spy.on(network, "SendObject")
+
+        sync:InitSync()
+        networkSpy:clear()
+
+        eventbus:PublishEvent(NetEvents.OfferSync,
+                {11, nil, myGlobalHash, myClassHash, myFTLHash}, "Dude")
+
+        AdvanceClock(TheClassicRace.Config.RequestSyncWait)
+
+        -- no sync exchange needed; the only traffic is the buddy ping on becoming ready
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.BuddyPing,
+                match.is_table(), "WHISPER", "Dude")
+        assert.spy(networkSpy).called_at_most(1)
+        assert.equals(true, sync.isReady)
+    end)
+
+    it("syncs only FTL when only the FTL hash differs", function()
+        local networkSpy = spy.on(network, "SendObject")
+
+        sync:InitSync()
+        networkSpy:clear()
+
+        eventbus:PublishEvent(NetEvents.OfferSync,
+                {11, nil, myGlobalHash, myClassHash, myFTLHash + 1}, "Dude")
+
+        AdvanceClock(TheClassicRace.Config.RequestSyncWait)
+
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync,
+                {11, myGlobalHash, myClassHash, myFTLHash}, "WHISPER", "Dude")
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.FTLSync, {""}, "WHISPER", "Dude")
+        assert.spy(networkSpy).called_at_most(2)
     end)
 
     it("can init and chooses preferred partner", function()
         local networkSpy = spy.on(network, "SendObject")
 
         sync:InitSync()
-
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.RequestSync, 11, "CHANNEL")
-        assert.spy(networkSpy).called_at_most(1)
         networkSpy:clear()
 
-        -- Dude provides a
+        -- Dude was synced recently (throttled), Chick was not
         eventbus:PublishEvent(NetEvents.OfferSync, {11, time}, "Dude")
         eventbus:PublishEvent(NetEvents.OfferSync, {11, nil}, "Chick")
 
@@ -114,28 +156,27 @@ describe("Sync", function()
         -- advance our clock so the sync happens
         AdvanceClock(TheClassicRace.Config.RequestSyncWait)
 
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync, 11, "WHISPER", "Chick")
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync,
+                match.is_table(), "WHISPER", "Chick")
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Chick")
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Chick")
-        assert.spy(networkSpy).called_at_most(3)
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.FTLSync, {""}, "WHISPER", "Chick")
+        assert.spy(networkSpy).called_at_most(4)
         networkSpy:clear()
 
         -- advance our clock so the retry happens
         AdvanceClock(TheClassicRace.Config.RetrySyncWait)
 
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync, 11, "WHISPER", "Dude")
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync,
+                match.is_table(), "WHISPER", "Dude")
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Dude")
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Dude")
-        assert.spy(networkSpy).called_at_most(3)
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.FTLSync, {""}, "WHISPER", "Dude")
+        assert.spy(networkSpy).called_at_most(4)
     end)
 
     it("can init and sync with partner, won't (re)try other partners", function()
         local networkSpy = spy.on(network, "SendObject")
 
         sync:InitSync()
-
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.RequestSync, 11, "CHANNEL")
-        assert.spy(networkSpy).called_at_most(1)
         networkSpy:clear()
 
         eventbus:PublishEvent(NetEvents.OfferSync, {11, nil}, "Dude")
@@ -149,28 +190,38 @@ describe("Sync", function()
         -- advance our clock so the sync happens
         AdvanceClock(TheClassicRace.Config.RequestSyncWait)
 
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync, 11, "WHISPER", "Dude")
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Dude")
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Dude")
-        assert.spy(networkSpy).called_at_most(3)
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync,
+                match.is_table(), "WHISPER", "Dude")
+
+        -- receive payload from Dude (also triggers buddy pings on becoming ready)
+        eventbus:PublishEvent(NetEvents.SyncPayload, "", "Dude")
+        assert.equals(true, sync.isReady)
         networkSpy:clear()
 
-        -- receive payload from Dude
-        eventbus:PublishEvent(NetEvents.SyncPayload, "", "Dude")
-
-        -- advance our clock so the retry happens
+        -- advance our clock so the retry would happen
         AdvanceClock(TheClassicRace.Config.RetrySyncWait)
 
         assert.spy(networkSpy).called_at_most(0)
+    end)
+
+    it("marks ready when receiving only an FTL payload", function()
+        sync:InitSync()
+
+        eventbus:PublishEvent(NetEvents.OfferSync, {11, nil}, "Dude")
+
+        AdvanceClock(TheClassicRace.Config.RequestSyncWait)
+        assert.equals(false, sync.isReady)
+
+        -- partner only had FTL differences to offer
+        eventbus:PublishEvent(NetEvents.FTLSync, {""}, "Dude")
+
+        assert.equals(true, sync.isReady)
     end)
 
     it("can init and retry sync with unresponsive partner", function()
         local networkSpy = spy.on(network, "SendObject")
 
         sync:InitSync()
-
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.RequestSync, 11, "CHANNEL")
-        assert.spy(networkSpy).called_at_most(1)
         networkSpy:clear()
 
         eventbus:PublishEvent(NetEvents.OfferSync, {11, nil}, "Dude")
@@ -184,22 +235,21 @@ describe("Sync", function()
         -- advance our clock so the sync happens
         AdvanceClock(TheClassicRace.Config.RequestSyncWait)
 
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync, 11, "WHISPER", "Dude")
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Dude")
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Dude")
-        assert.spy(networkSpy).called_at_most(3)
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync,
+                match.is_table(), "WHISPER", "Dude")
         networkSpy:clear()
 
         -- advance our clock so the retry happens
         AdvanceClock(TheClassicRace.Config.RetrySyncWait)
 
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync, 11, "WHISPER", "Chick")
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync,
+                match.is_table(), "WHISPER", "Chick")
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Chick")
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Chick")
-        assert.spy(networkSpy).called_at_most(3)
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.FTLSync, {""}, "WHISPER", "Chick")
+        assert.spy(networkSpy).called_at_most(4)
     end)
 
-    it("can offer and sync", function()
+    it("can offer and sync with old client that sends no hashes", function()
         local networkSpy = spy.on(network, "SendObject")
 
         -- mark as ready
@@ -207,15 +257,62 @@ describe("Sync", function()
 
         eventbus:PublishEvent(NetEvents.RequestSync, 11, "Dude")
 
-        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.OfferSync, {11, nil}, "WHISPER", "Dude")
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.OfferSync,
+                {11, nil, myGlobalHash, myClassHash, myFTLHash}, "WHISPER", "Dude")
         assert.spy(networkSpy).called_at_most(1)
         networkSpy:clear()
 
         eventbus:PublishEvent(NetEvents.StartSync, 11, "Dude")
 
+        -- old client provided no hashes -> send global + class leaderboards and FTL
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Dude")
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.FTLSync, {""}, "WHISPER", "Dude")
+        assert.spy(networkSpy).called_at_most(3)
+    end)
+
+    it("won't offer to a requester whose hashes match ours", function()
+        local networkSpy = spy.on(network, "SendObject")
+
+        -- mark as ready
+        sync.isReady = true
+
+        eventbus:PublishEvent(NetEvents.RequestSync,
+                {11, myGlobalHash, myClassHash, myFTLHash}, "Dude")
+
+        assert.spy(networkSpy).called_at_most(0)
+    end)
+
+    it("offers when the requester's class leaderboard differs", function()
+        local networkSpy = spy.on(network, "SendObject")
+
+        -- mark as ready
+        sync.isReady = true
+
+        eventbus:PublishEvent(NetEvents.RequestSync,
+                {11, myGlobalHash, myClassHash + 1, myFTLHash}, "Dude")
+
+        assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.OfferSync,
+                {11, nil, myGlobalHash, myClassHash, myFTLHash}, "WHISPER", "Dude")
+        assert.spy(networkSpy).called_at_most(1)
+    end)
+
+    it("sends nothing on StartSync when the requester's hashes match", function()
+        local networkSpy = spy.on(network, "SendObject")
+
+        eventbus:PublishEvent(NetEvents.StartSync,
+                {11, myGlobalHash, myClassHash, myFTLHash}, "Dude")
+
+        assert.spy(networkSpy).called_at_most(0)
+    end)
+
+    it("sends only the differing leaderboard on StartSync", function()
+        local networkSpy = spy.on(network, "SendObject")
+
+        eventbus:PublishEvent(NetEvents.StartSync,
+                {11, myGlobalHash + 1, myClassHash, myFTLHash}, "Dude")
+
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Dude")
-        assert.spy(networkSpy).called_at_most(2)
+        assert.spy(networkSpy).called_at_most(1)
     end)
 
     it("won't offer when not ready offer and sync", function()
@@ -260,6 +357,132 @@ describe("Sync", function()
         sync:InitSync()
 
         assert.spy(networkSpy).called_at_most(0)
+    end)
+
+    describe("guild sync", function()
+        it("won't offer when the announcer's hashes match ours", function()
+            local networkSpy = spy.on(network, "SendObject")
+            sync.isReady = true
+
+            eventbus:PublishEvent(NetEvents.GuildSync, {11, myFullHash, time, myFTLHash}, "Dude")
+            AdvanceClock(TheClassicRace.Config.GuildSyncWait)
+
+            assert.spy(networkSpy).called_at_most(0)
+        end)
+
+        it("offers when only the announcer's FTL hash differs", function()
+            local networkSpy = spy.on(network, "SendObject")
+            sync.isReady = true
+
+            eventbus:PublishEvent(NetEvents.GuildSync, {11, myFullHash, time, myFTLHash + 1}, "Dude")
+            AdvanceClock(TheClassicRace.Config.GuildSyncWait)
+
+            assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.GuildOffer,
+                    {11, nil, myFullHash, myGlobalHash, myClassHash, core:LoginTime(), myFTLHash},
+                    "WHISPER", "Dude")
+            assert.spy(networkSpy).called_at_most(1)
+        end)
+
+        it("offers to an old client that announces a differing full hash without FTL", function()
+            local networkSpy = spy.on(network, "SendObject")
+            sync.isReady = true
+
+            eventbus:PublishEvent(NetEvents.GuildSync, {11, myFullHash + 1, time}, "Dude")
+            AdvanceClock(TheClassicRace.Config.GuildSyncWait)
+
+            assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.GuildOffer,
+                    match.is_table(), "WHISPER", "Dude")
+            assert.spy(networkSpy).called_at_most(1)
+        end)
+
+        it("starts guild sync with the best partner only when hashes differ", function()
+            local networkSpy = spy.on(network, "SendObject")
+            _G.SetIsInGuild(true)
+
+            sync:SendGuildSync()
+            networkSpy:clear()
+
+            -- partner fully in sync with us -> nothing to do
+            eventbus:PublishEvent(NetEvents.GuildOffer,
+                    {11, nil, myFullHash, myGlobalHash, myClassHash, time - 100, myFTLHash}, "Dude")
+            AdvanceClock(TheClassicRace.Config.GuildSyncWait + 1)
+
+            assert.spy(networkSpy).called_at_most(0)
+        end)
+
+        it("starts guild sync when the best partner's FTL differs", function()
+            local networkSpy = spy.on(network, "SendObject")
+            _G.SetIsInGuild(true)
+
+            sync:SendGuildSync()
+            networkSpy:clear()
+
+            eventbus:PublishEvent(NetEvents.GuildOffer,
+                    {11, nil, myFullHash, myGlobalHash, myClassHash, time - 100, myFTLHash + 1}, "Dude")
+            AdvanceClock(TheClassicRace.Config.GuildSyncWait + 1)
+
+            assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync,
+                    match.is_table(), "WHISPER", "Dude")
+            assert.spy(networkSpy).called_at_most(1)
+        end)
+
+        it("skips the FTL payload when a guild STARTSYNC carries a matching FTL hash", function()
+            local networkSpy = spy.on(network, "SendObject")
+
+            local perClassHashes = {}
+            for classIndex = 0, #TheClassicRace.Config.Classes do
+                perClassHashes[classIndex + 1] = TheClassicRace.Leaderboard.ComputeHash(
+                        db.factionrealm.leaderboard[classIndex])
+            end
+
+            eventbus:PublishEvent(NetEvents.StartSync, {11, perClassHashes, myFTLHash}, "Dude")
+            assert.spy(networkSpy).called_at_most(0)
+
+            eventbus:PublishEvent(NetEvents.StartSync, {11, perClassHashes, myFTLHash + 1}, "Dude")
+            assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.FTLSync,
+                    {""}, "WHISPER", "Dude")
+            assert.spy(networkSpy).called_at_most(1)
+        end)
+
+        it("always sends the FTL payload to an old client guild STARTSYNC", function()
+            local networkSpy = spy.on(network, "SendObject")
+
+            local perClassHashes = {}
+            for classIndex = 0, #TheClassicRace.Config.Classes do
+                perClassHashes[classIndex + 1] = TheClassicRace.Leaderboard.ComputeHash(
+                        db.factionrealm.leaderboard[classIndex])
+            end
+
+            eventbus:PublishEvent(NetEvents.StartSync, {11, perClassHashes}, "Dude")
+            assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.FTLSync,
+                    {""}, "WHISPER", "Dude")
+            assert.spy(networkSpy).called_at_most(1)
+        end)
+    end)
+
+    describe("buddies", function()
+        it("normalizes same-realm buddy names to their short form", function()
+            sync:AddBuddy("Dude-NubVille")
+            sync:AddBuddy("Dude")
+
+            local count = 0
+            for name, _ in pairs(db.factionrealm.buddies) do
+                assert.equals("Dude", name)
+                count = count + 1
+            end
+            assert.equals(1, count)
+        end)
+
+        it("never adds ourselves as buddy", function()
+            sync:AddBuddy("Nub")
+            sync:AddBuddy("Nub-NubVille")
+
+            local count = 0
+            for _ in pairs(db.factionrealm.buddies) do
+                count = count + 1
+            end
+            assert.equals(0, count)
+        end)
     end)
 
     it("produces proper payload for global leaderboard", function()
@@ -314,7 +537,7 @@ describe("Sync", function()
                     {name = "Nubthree", level = 5, dingedAt = time, classIndex = 6},
                     {name = "Nubfour", level = 5, dingedAt = time + 10, classIndex = 5},
                     {name = "Nubfive", level = 5, dingedAt = time - 11, classIndex = 4},
-                }), false)
+                }))
         assert.spy(eventBusSpy).called_at_most(1)
     end)
 end)

--- a/tests/tracker.lua
+++ b/tests/tracker.lua
@@ -243,6 +243,12 @@ describe("Tracker", function()
             assert.equals("Alice", db.factionrealm.firstToLevel[0][15].name)
         end)
 
+        it("UpdatePioneers uses name as tiebreaker when dingedAt is equal", function()
+            tracker:ProcessPlayerInfo(playerInfo("Zebra",    15, WARRIORIDX, time))
+            tracker:ProcessPlayerInfo(playerInfo("Aardvark", 15, DRUIDIDX,   time))
+            assert.equals("Aardvark", db.factionrealm.firstToLevel[0][15].name)
+        end)
+
         it("UpdatePlayerHistory records dingedAt per level", function()
             tracker:ProcessPlayerInfo(playerInfo("Alice", 15, DRUIDIDX, time))
             local hist = db.factionrealm.playerHistory["Alice"]

--- a/tests/tracker.lua
+++ b/tests/tracker.lua
@@ -198,6 +198,92 @@ describe("Tracker", function()
         end)
     end)
 
+    describe("Pioneers", function()
+        it("UpdatePioneers sets raceStartedAt on first player", function()
+            tracker:ProcessPlayerInfo(playerInfo("Alice", 15, DRUIDIDX, time))
+            assert.equals(time, db.factionrealm.raceStartedAt)
+        end)
+
+        it("UpdatePioneers updates raceStartedAt to the minimum seen", function()
+            tracker:ProcessPlayerInfo(playerInfo("Alice", 15, DRUIDIDX, time))
+            tracker:ProcessPlayerInfo(playerInfo("Bob", 16, WARRIORIDX, time - 100))
+            assert.equals(time - 100, db.factionrealm.raceStartedAt)
+        end)
+
+        it("UpdatePioneers does not lower raceStartedAt for a later timestamp", function()
+            tracker:ProcessPlayerInfo(playerInfo("Bob", 16, WARRIORIDX, time - 100))
+            tracker:ProcessPlayerInfo(playerInfo("Alice", 15, DRUIDIDX, time))
+            assert.equals(time - 100, db.factionrealm.raceStartedAt)
+        end)
+
+        it("UpdatePioneers records first player to reach each level (overall)", function()
+            tracker:ProcessPlayerInfo(playerInfo("Alice", 15, DRUIDIDX, time))
+            local ftl0 = db.factionrealm.firstToLevel[0]
+            assert.equals("Alice",   ftl0[15].name)
+            assert.equals(DRUIDIDX,  ftl0[15].classIndex)
+            assert.equals(time,      ftl0[15].dingedAt)
+        end)
+
+        it("UpdatePioneers records first player to reach each level (per class)", function()
+            tracker:ProcessPlayerInfo(playerInfo("Alice", 15, DRUIDIDX, time))
+            local ftlDruid = db.factionrealm.firstToLevel[DRUIDIDX]
+            assert.equals("Alice", ftlDruid[15].name)
+            assert.equals(time,    ftlDruid[15].dingedAt)
+        end)
+
+        it("UpdatePioneers keeps earliest record per level (overall)", function()
+            tracker:ProcessPlayerInfo(playerInfo("Bob",   15, WARRIORIDX, time))
+            tracker:ProcessPlayerInfo(playerInfo("Alice", 15, DRUIDIDX,   time - 100))
+            assert.equals("Alice", db.factionrealm.firstToLevel[0][15].name)
+        end)
+
+        it("UpdatePioneers does not overwrite an earlier record with a later one", function()
+            tracker:ProcessPlayerInfo(playerInfo("Alice", 15, DRUIDIDX,   time - 100))
+            tracker:ProcessPlayerInfo(playerInfo("Bob",   15, WARRIORIDX, time))
+            assert.equals("Alice", db.factionrealm.firstToLevel[0][15].name)
+        end)
+
+        it("UpdatePlayerHistory records dingedAt per level", function()
+            tracker:ProcessPlayerInfo(playerInfo("Alice", 15, DRUIDIDX, time))
+            local hist = db.factionrealm.playerHistory["Alice"]
+            assert.equals(time,     hist.levels[15])
+            assert.equals(DRUIDIDX, hist.classIndex)
+        end)
+
+        it("UpdatePlayerHistory keeps earliest dingedAt per level", function()
+            tracker:ProcessPlayerInfo(playerInfo("Alice", 15, DRUIDIDX, time))
+            tracker:ProcessPlayerInfo(playerInfo("Alice", 15, DRUIDIDX, time - 50))
+            assert.equals(time - 50, db.factionrealm.playerHistory["Alice"].levels[15])
+        end)
+
+        it("OnFTLSyncResult merges remote firstToLevel into local DB", function()
+            local ftldb = {
+                [0] = {[10] = {name = "Remote", classIndex = WARRIORIDX, dingedAt = time - 200}},
+            }
+            tracker:OnFTLSyncResult(ftldb)
+            assert.equals("Remote",  db.factionrealm.firstToLevel[0][10].name)
+            assert.equals(time - 200, db.factionrealm.raceStartedAt)
+        end)
+
+        it("OnFTLSyncResult keeps local record when it is earlier", function()
+            tracker:ProcessPlayerInfo(playerInfo("Local", 10, DRUIDIDX, time - 500))
+            local ftldb = {
+                [0] = {[10] = {name = "Remote", classIndex = WARRIORIDX, dingedAt = time - 200}},
+            }
+            tracker:OnFTLSyncResult(ftldb)
+            assert.equals("Local", db.factionrealm.firstToLevel[0][10].name)
+        end)
+
+        it("OnFTLSyncResult overwrites local record when remote is earlier", function()
+            tracker:ProcessPlayerInfo(playerInfo("Local", 10, DRUIDIDX, time - 100))
+            local ftldb = {
+                [0] = {[10] = {name = "Remote", classIndex = WARRIORIDX, dingedAt = time - 500}},
+            }
+            tracker:OnFTLSyncResult(ftldb)
+            assert.equals("Remote", db.factionrealm.firstToLevel[0][10].name)
+        end)
+    end)
+
     describe("RaceFinished", function()
         it("produces RaceFinished event once", function()
             local eventBusSpy = spy.on(eventbus, "PublishEvent")

--- a/tests/tracker.lua
+++ b/tests/tracker.lua
@@ -63,6 +63,7 @@ describe("Tracker", function()
 
 
     before_each(function()
+        _G.C_Timer.Reset()
         config = merge(TheClassicRace.Config, {MaxLeaderboardSize = 5})
         db = LibStub("AceDB-3.0"):New("TheClassicRace_DB", TheClassicRace.DefaultDB, true)
         db:ResetDB()
@@ -160,7 +161,7 @@ describe("Tracker", function()
             assert.spy(networkSpy).was_not_called()
         end)
 
-        it("should bump ticker on OnNetPlayerInfo", function()
+        it("should publish Ding on OnNetPlayerInfo", function()
             local eventBusSpy = spy.on(eventbus, "PublishEvent")
 
             tracker:OnNetPlayerInfoBatch({
@@ -169,21 +170,37 @@ describe("Tracker", function()
                 }), false, DRUIDIDX
             })
 
-            assert.spy(eventBusSpy).was_called_with(match.is_ref(eventbus), config.Events.BumpScan, DRUIDIDX)
             assert.spy(eventBusSpy).was_called_with(match.is_ref(eventbus), config.Events.Ding,
                     match.is_table(), 1, 1)
 
-            assert.spy(eventBusSpy).called_at_most(2)
+            assert.spy(eventBusSpy).called_at_most(1)
+        end)
+
+        it("handles unknown classIndex (0) in a batch without error", function()
+            tracker:OnNetPlayerInfoBatch({
+                TheClassicRace.Serializer.SerializePlayerInfoBatch({
+                    {name = "Nubone", level = 7, classIndex = 0, dingedAt = 100},
+                }), false, 0
+            })
+
+            assert.equals(1, #db.factionrealm.leaderboard[0].players)
+            assert.equals(0, db.factionrealm.leaderboard[0].players[1].classIndex)
         end)
 
         it("should broadcast to network OnSlashWhoResult", function()
             local networkSpy = spy.on(network, "SendObject")
 
             tracker:OnSlashWhoResult({ playerInfo("Nubone", 5), })
+            -- yells immediately for real-time zone updates
             assert.spy(networkSpy).was_called_with(match.is_ref(network), config.Network.Events.PlayerInfoBatch,
-                    match.is_table(), "CHANNEL")
+                    match.is_table(), "YELL")
+            assert.spy(networkSpy).called_at_most(1)
+
+            -- guild push is batched behind DingPushDelay
+            _G.C_Timer.Advance(config.DingPushDelay)
             assert.spy(networkSpy).was_called_with(match.is_ref(network), config.Network.Events.PlayerInfoBatch,
                     match.is_table(), "GUILD")
+            assert.spy(networkSpy).called_at_most(2)
         end)
 
         it("should broadcast to network OnSlashWhoResult, not to guild when not in guild", function()
@@ -193,7 +210,10 @@ describe("Tracker", function()
 
             tracker:OnSlashWhoResult({ playerInfo("Nubone", 5), })
             assert.spy(networkSpy).was_called_with(match.is_ref(network), config.Network.Events.PlayerInfoBatch,
-                    match.is_table(), "CHANNEL")
+                    match.is_table(), "YELL")
+            assert.spy(networkSpy).called_at_most(1)
+
+            _G.C_Timer.Advance(config.DingPushDelay)
             assert.spy(networkSpy).called_at_most(1)
         end)
     end)
@@ -325,11 +345,97 @@ describe("Tracker", function()
             assert.spy(lbSpies[PRIESTIDX]).was_called_with(match.is_ref(tracker.lbPerClass[PRIESTIDX]), nub5)
 
             assert.equals(3, #db.factionrealm.leaderboard[0].players)
+            -- canonical order: level desc, dingedAt asc, name asc
             assert.same({
-                {name = "Nubthree", level = 5, dingedAt = time, classIndex = DRUIDIDX},
-                {name = "Nubfour", level = 5, dingedAt = time, classIndex = PALADINIDX},
                 {name = "Nubfive", level = 5, dingedAt = time - 100, classIndex = PRIESTIDX},
+                {name = "Nubfour", level = 5, dingedAt = time, classIndex = PALADINIDX},
+                {name = "Nubthree", level = 5, dingedAt = time, classIndex = DRUIDIDX},
             }, db.factionrealm.leaderboard[0].players)
+        end)
+    end)
+
+    describe("Convergence", function()
+        it("NormalizeDB re-sorts legacy leaderboard order and floors timestamps", function()
+            db.factionrealm.leaderboard[0].players = {
+                {name = "Zebra", level = 5, dingedAt = time + 0.7, classIndex = DRUIDIDX},
+                {name = "Aardvark", level = 5, dingedAt = time, classIndex = WARRIORIDX},
+                {name = "Top", level = 7, dingedAt = time, classIndex = PRIESTIDX},
+            }
+
+            -- constructing a tracker normalizes the persisted data
+            TheClassicRace.Tracker(config, core, db, TheClassicRace.EventBus(), network)
+
+            assert.same({
+                {name = "Top", level = 7, dingedAt = time, classIndex = PRIESTIDX},
+                {name = "Aardvark", level = 5, dingedAt = time, classIndex = WARRIORIDX},
+                {name = "Zebra", level = 5, dingedAt = time, classIndex = DRUIDIDX},
+            }, db.factionrealm.leaderboard[0].players)
+        end)
+
+        it("clients converge on identical hashes after one bidirectional sync", function()
+            -- regression for issue #16: A knows the player's class at a stale lower
+            -- level, B has the newer level but doesn't know the class
+            local dbB = LibStub("AceDB-3.0"):New("TheClassicRace_DB_B", TheClassicRace.DefaultDB, true)
+            dbB:ResetDB()
+            local trackerB = TheClassicRace.Tracker(config, core, dbB, TheClassicRace.EventBus(), network)
+
+            tracker:ProcessPlayerInfo({name = "Racer", level = 20, classIndex = DRUIDIDX, dingedAt = time - 100})
+            trackerB:ProcessPlayerInfo({name = "Racer", level = 25, classIndex = 0, dingedAt = time})
+            assert.not_equals(tracker:ComputeFullHash(), trackerB:ComputeFullHash())
+
+            -- exchange all leaderboards both ways through the wire format,
+            -- snapshotting both sides first like the real sync exchange does
+            local wire = function(t)
+                local strs = {}
+                for _, b in ipairs(t:CollectBatches(nil) or {}) do
+                    strs[#strs + 1] = TheClassicRace.Serializer.SerializePlayerInfoBatch(b.players)
+                end
+                return strs
+            end
+            local batchesA, batchesB = wire(tracker), wire(trackerB)
+            for _, str in ipairs(batchesB) do
+                tracker:OnSyncResult(TheClassicRace.Serializer.DeserializePlayerInfoBatch(str))
+            end
+            for _, str in ipairs(batchesA) do
+                trackerB:OnSyncResult(TheClassicRace.Serializer.DeserializePlayerInfoBatch(str))
+            end
+
+            assert.equals(tracker:ComputeFullHash(), trackerB:ComputeFullHash())
+            -- both ended up with the latest level and the known class
+            assert.same({name = "Racer", level = 25, dingedAt = time, classIndex = DRUIDIDX},
+                    db.factionrealm.leaderboard[0].players[1])
+            assert.same({name = "Racer", level = 25, dingedAt = time, classIndex = DRUIDIDX},
+                    dbB.factionrealm.leaderboard[0].players[1])
+        end)
+
+        it("UpdatePioneers ignores level 1", function()
+            tracker:ProcessPlayerInfo(playerInfo("Fresh", 1, DRUIDIDX, time))
+            assert.is_nil(db.factionrealm.firstToLevel[0])
+        end)
+
+        it("OnFTLSyncResult fills in a missing classIndex on otherwise identical records", function()
+            tracker:ProcessPlayerInfo({name = "Racer", level = 10, classIndex = 0, dingedAt = time})
+            assert.equals(0, db.factionrealm.firstToLevel[0][10].classIndex)
+
+            tracker:OnFTLSyncResult({
+                [0] = {[10] = {name = "Racer", classIndex = DRUIDIDX, dingedAt = time}},
+            })
+
+            assert.equals(DRUIDIDX, db.factionrealm.firstToLevel[0][10].classIndex)
+        end)
+
+        it("OnFTLSyncResult ignores records that don't fit the wire format", function()
+            tracker:OnFTLSyncResult({
+                [0] = {
+                    [1] = {name = "Fresh", classIndex = DRUIDIDX, dingedAt = time},
+                    [100] = {name = "Impossible", classIndex = DRUIDIDX, dingedAt = time},
+                    [10] = {name = "Racer", classIndex = DRUIDIDX, dingedAt = time},
+                },
+            })
+
+            assert.is_nil(db.factionrealm.firstToLevel[0][1])
+            assert.is_nil(db.factionrealm.firstToLevel[0][100])
+            assert.equals("Racer", db.factionrealm.firstToLevel[0][10].name)
         end)
     end)
 end)


### PR DESCRIPTION
## Summary

Adds a **Pioneers** view to the main status frame that shows which player was first detected at each level (from max level down to 2), with how long after the race start that happened. Toggled by a running-figure icon (Achievement_GuildPerk_FastTrack) on the **left side** of the existing frame. The class filter tabs on the right work in both views.

### What the Pioneers tab shows

\`\`\`
00:01:23:45  Lvl 60: Asmongold        ← class colored, time since race start
00:01:10:02  Lvl 59: Swifty
...
             Lvl 38: no data          ← grey, level not yet detected by anyone
...
00:00:04:11  Lvl  2: Preach
\`\`\`

- Levels with a record show \`dd:hh:mm:ss Lvl NN: PlayerName\` in the player's class color.
- Levels with no detected player show grey **"no data"**.
- Class filter tabs let you see "first Warrior to reach each level", "first Hunter", etc.

---

## Data layer

| Field | Location | Purpose |
|-------|----------|---------|
| \`raceStartedAt\` | \`factionrealm\` | Earliest \`dingedAt\` ever seen; used as race-start reference for elapsed-time display |
| \`playerHistory[name]\` | \`factionrealm\` | Per-character level history \`{classIndex, levels={[level]=dingedAt}}\` — persisted for every detected player; foundation for a future per-character timeline view |
| \`firstToLevel[classFilter][level]\` | \`factionrealm\` | \`{name, classIndex, dingedAt}\` — the pioneering record per level, for overall (0) and each class filter (1–11) |
| \`pioneersMigrated\` | \`factionrealm\` | One-time flag; on first load after upgrade, seeds pioneer data from whatever leaderboard entries already exist |

Every call to \`tracker:ProcessPlayerInfo\` (from scan, network batch, or sync) now updates both \`playerHistory\` and \`firstToLevel\`, so any detected player can hold a pioneer record even if they never make the top 50.

---

## Sync

- New network event \`FTLSYNC\` carries a compact serialized \`firstToLevel\` batch. Format per record: \`CF(2) LV(2) CI(2) name dingedAtDelta $\` with a 10-digit base offset — same compression scheme as the existing player batch.
- FTL hash added to \`REQSYNC\`, \`OFFERSYNC\`, \`STARTSYNC\`, \`BPING\`, \`BPONG\` payloads. Partners skip sending when hashes already agree.
- Merging always keeps the **earlier** \`dingedAt\` per \`(classFilter, level)\` slot.
- Old clients receive \`FTLSYNC\` messages silently (no registered handler → ignored). Old-format payloads in existing events handled gracefully (nil hash → treat as needs sync).

---

## Files changed

| File | Change |
|------|--------|
| \`src/defaultdb.lua\` | Add \`raceStartedAt\`, \`playerHistory\`, \`firstToLevel\`, \`pioneersMigrated\` |
| \`src/config.lua\` | Add \`FTLSync\` network event, \`FTLSyncResult\` local event |
| \`src/core/tracker.lua\` | \`UpdatePioneers\`, \`UpdatePlayerHistory\`, \`OnFTLSyncResult\` methods |
| \`src/core/serializer.lua\` | \`SerializeFTLBatch\` / \`DeserializeFTLBatch\` |
| \`src/core/sync.lua\` | FTL hash in all handshake payloads; \`SyncFTL\`, \`OnNetFTLSync\` |
| \`src/gui/pioneers-frame.lua\` | **New** — scrollable per-level list renderer |
| \`src/gui/status-frame.lua\` | Left-side view-toggle icon; \`RenderLeaderboard\` extracted; \`view\` state |
| \`TheClassicRace.toc\` | Load \`pioneers-frame.lua\` before \`status-frame.lua\` |
| \`src/main.lua\` | \`MigratePioneerData\` one-time seeder in \`DBMigrations\` |
| \`tests/tracker.lua\` | 10 new pioneer-tracking tests |
| \`tests/serializer.lua\` | 4 new FTL serializer tests |

---

## Test plan

- [ ] Load addon fresh (empty DB) → Pioneers tab shows all levels as "no data"
- [ ] Scan some players → levels they were detected at populate with correct elapsed time
- [ ] Toggle Pioneers icon → view switches; toggle again → back to leaderboard
- [ ] Select a class tab in Pioneers view → only that class's first-to-level records shown
- [ ] Log in alongside another player who has pioneer data → FTLSYNC received and merged; earlier records win
- [ ] Existing install upgrade → \`pioneersMigrated\` seeds from existing leaderboard data
- [ ] \`make tests\` (when Lua toolchain available) → all serializer and tracker tests pass

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/claude-code)