### PR TITLE
Sync playerHistory once per login, scoped to leaderboard players

### DIFF
--- a/src/config.lua
+++ b/src/config.lua
@@ -130,6 +130,12 @@ local TheClassicRaceConfig = {
 
     DingPushDelay = 10,        -- seconds to batch dings before pushing to guild + buddies
 
+    -- playerHistory sync: potentially large (hundreds of players x dozens of levels),
+    -- so it's transferred only once per login (pull-only, toward the player who just
+    -- logged in) and chunked to stay friendly to the addon channel throttle
+    PlayerHistoryChunkSize = 20,   -- players per PHSYNC message
+    PlayerHistoryChunkDelay = 2,   -- seconds between PHSYNC messages
+
     Network = {
         Prefix = "TCRace",
         Events = {
@@ -145,6 +151,7 @@ local TheClassicRaceConfig = {
             BuddyPing = "BPING",
             BuddyPong = "BPONG",
             FTLSync = "FTLSYNC",
+            PlayerHistorySync = "PHSYNC",
         },
     },
     Events = {
@@ -152,6 +159,7 @@ local TheClassicRaceConfig = {
         SlashWhoResult = "WHO_RESULT",
         SyncResult = "SYNC_RESULT",
         FTLSyncResult = "FTL_SYNC_RESULT",
+        PHSyncResult = "PH_SYNC_RESULT",
         Ding = "DING",
         -- ScanFinished(endofrace)
         -- should use RaceFinished though if interested in when the race is finished,

--- a/src/core/serializer.lua
+++ b/src/core/serializer.lua
@@ -136,6 +136,92 @@ function TheClassicRaceSerializer.SerializeFTLBatch(firstToLevel)
     return res
 end
 
+-- Serializes playerHistory for the given player names into chunk strings of at most
+-- chunkSize players each. Each chunk is independently parseable (own offset header)
+-- so partial delivery of a multi-chunk sync still merges cleanly.
+-- Chunk format: offset(10) $ record $ record $ ...
+-- Record format: classIndex(2) name (":" level(2) delta)+
+-- playerHistory[name] = {classIndex = ci, levels = {[level] = dingedAt}}
+function TheClassicRaceSerializer.SerializePlayerHistoryChunks(playerHistory, names, chunkSize)
+    -- collect valid records first: players with at least one level that fits the wire format
+    local records = {}
+    for _, name in ipairs(names) do
+        local hist = playerHistory[name]
+        if hist ~= nil and hist.levels ~= nil then
+            local levels = {}
+            for level, dingedAt in pairs(hist.levels) do
+                if level >= 2 and level <= 99 and dingedAt ~= nil then
+                    levels[#levels + 1] = {level = level, dingedAt = math.floor(dingedAt)}
+                end
+            end
+            if #levels > 0 then
+                table.sort(levels, function(a, b) return a.level < b.level end)
+                records[#records + 1] = {name = name, classIndex = hist.classIndex or 0, levels = levels}
+            end
+        end
+    end
+
+    local chunks = {}
+    for chunkStart = 1, #records, chunkSize do
+        local chunkEnd = math.min(chunkStart + chunkSize - 1, #records)
+
+        local offset = nil
+        for i = chunkStart, chunkEnd do
+            for _, entry in ipairs(records[i].levels) do
+                if offset == nil or entry.dingedAt < offset then offset = entry.dingedAt end
+            end
+        end
+
+        local res = string.sub("0000000000" .. offset, -10) .. "$"
+        for i = chunkStart, chunkEnd do
+            local record = records[i]
+            local str = string.format("%02d", record.classIndex) .. record.name
+            for _, entry in ipairs(record.levels) do
+                str = str .. ":" .. string.format("%02d", entry.level) .. (entry.dingedAt - offset)
+            end
+            res = res .. str .. "$"
+        end
+        chunks[#chunks + 1] = res
+    end
+
+    return chunks
+end
+
+-- Deserializes a single playerHistory chunk produced by SerializePlayerHistoryChunks.
+-- Returns {[name] = {classIndex = ci, levels = {[level] = dingedAt}}}.
+function TheClassicRaceSerializer.DeserializePlayerHistoryBatch(str)
+    if str == "" then
+        return {}
+    end
+
+    local offset = tonumber(string.sub(str, 1, 10))
+    str = string.sub(str, 12)
+
+    local batch = {}
+    for substr in string.gmatch(str, "([^$]+)") do
+        -- record: classIndex(2) name, then one or more ":" level(2) delta groups
+        local ci, name, levelstr = string.match(substr, "^(%d%d)([^:]+)(:.+)$")
+        if ci and name and levelstr then
+            local levels = {}
+            local count = 0
+            for lv, delta in string.gmatch(levelstr, ":(%d%d)(%d+)") do
+                local level = tonumber(lv)
+                local dingedAt = tonumber(delta) + offset
+                -- level 1 is not a ding — ignore malformed remote entries
+                if level >= 2 and (levels[level] == nil or dingedAt < levels[level]) then
+                    levels[level] = dingedAt
+                    count = count + 1
+                end
+            end
+            if count > 0 then
+                batch[name] = {classIndex = tonumber(ci), levels = levels}
+            end
+        end
+    end
+
+    return batch
+end
+
 -- Deserializes a firstToLevel batch string produced by SerializeFTLBatch.
 -- When duplicate (classFilter, level) entries appear, keeps the one with the earlier dingedAt.
 function TheClassicRaceSerializer.DeserializeFTLBatch(str)

--- a/src/core/sync.lua
+++ b/src/core/sync.lua
@@ -43,6 +43,50 @@ local function computeFTLHash(db, config)
     return hash
 end
 
+-- Sorted list of names that have playerHistory AND are on any leaderboard.
+-- playerHistory itself is unbounded (every character a scan ever saw), so both the
+-- history hash and the history sync payload are scoped to this bounded subset.
+local function relevantHistoryNames(db, config)
+    local onLeaderboard = {}
+    for classIndex = 0, #config.Classes do
+        local lb = db.factionrealm.leaderboard[classIndex]
+        if lb then
+            for _, player in ipairs(lb.players) do
+                onLeaderboard[player.name] = true
+            end
+        end
+    end
+
+    local names = {}
+    for name, _ in pairs(db.factionrealm.playerHistory or {}) do
+        if onLeaderboard[name] then
+            names[#names + 1] = name
+        end
+    end
+    table.sort(names)
+    return names
+end
+
+-- djb2 hash over the leaderboard-scoped playerHistory subset in deterministic order
+local function computePHHash(db, config)
+    local hash = 5381
+    local playerHistory = db.factionrealm.playerHistory or {}
+    for _, name in ipairs(relevantHistoryNames(db, config)) do
+        local hist = playerHistory[name]
+        local entry = name .. ":" .. (hist.classIndex or 0)
+        for level = 2, 99 do
+            local dingedAt = hist.levels ~= nil and hist.levels[level] or nil
+            if dingedAt ~= nil then
+                entry = entry .. ":" .. level .. ":" .. math.floor(dingedAt)
+            end
+        end
+        for i = 1, #entry do
+            hash = ((hash * 33) + string.byte(entry, i)) % 2147483647
+        end
+    end
+    return hash
+end
+
 --[[
 TheClassicRaceSync handles both requesting a sync when we login and responding to others who are request a sync
 ]]--
@@ -63,6 +107,7 @@ setmetatable(TheClassicRaceSync, {
 -- exposed as statics for tests and diagnostics
 TheClassicRaceSync.ComputeFTLHash = computeFTLHash
 TheClassicRaceSync.ComputeFullHash = computeFullHash
+TheClassicRaceSync.ComputePHHash = computePHHash
 
 function TheClassicRaceSync.new(Config, Core, DB, EventBus, Network)
     local self = setmetatable({}, TheClassicRaceSync)
@@ -80,6 +125,7 @@ function TheClassicRaceSync.new(Config, Core, DB, EventBus, Network)
     self.syncPartner = nil
     self.lastSync = nil
     self.guildOffers = nil  -- non-nil only during active guild sync window
+    self.guildPHWanted = false  -- whether the open guild window should also pull player history
 
     EventBus:RegisterCallback(self.Config.Network.Events.RequestSync, self, self.OnNetRequestSync)
     EventBus:RegisterCallback(self.Config.Network.Events.OfferSync, self, self.OnNetOfferSync)
@@ -90,6 +136,7 @@ function TheClassicRaceSync.new(Config, Core, DB, EventBus, Network)
     EventBus:RegisterCallback(self.Config.Network.Events.BuddyPing, self, self.OnNetBuddyPing)
     EventBus:RegisterCallback(self.Config.Network.Events.BuddyPong, self, self.OnNetBuddyPong)
     EventBus:RegisterCallback(self.Config.Network.Events.FTLSync, self, self.OnNetFTLSync)
+    EventBus:RegisterCallback(self.Config.Network.Events.PlayerHistorySync, self, self.OnNetPHSync)
 
     return self
 end
@@ -104,12 +151,13 @@ function TheClassicRaceSync:InitSync()
         return
     end
 
-    -- include our leaderboard and FTL hashes so partners can skip offering when already in sync
+    -- include our leaderboard, FTL and history hashes so partners can skip offering when already in sync
     local globalHash = TheClassicRace.Leaderboard.ComputeHash(self.DB.factionrealm.leaderboard[0])
     local classHash = TheClassicRace.Leaderboard.ComputeHash(
             self.DB.factionrealm.leaderboard[self.classIndex] or {players = {}})
     local ftlHash = computeFTLHash(self.DB, self.Config)
-    local payload = {self.classIndex, globalHash, classHash, ftlHash}
+    local phHash = computePHHash(self.DB, self.Config)
+    local payload = {self.classIndex, globalHash, classHash, ftlHash, phHash}
 
     self.Network:SendObject(self.Config.Network.Events.RequestSync, payload, "YELL")
 
@@ -118,7 +166,8 @@ function TheClassicRaceSync:InitSync()
     C_Timer.After(self.Config.RequestSyncWait, function() _self:DoSync() end)
 
     -- guild sync: announce to GUILD and pick the longest-uptime partner after GuildSyncWait+1s
-    self:SendGuildSync()
+    -- withPlayerHistory: we just logged in, so this is the once-per-login history pull
+    self:SendGuildSync(true)
 end
 
 function TheClassicRaceSync:OnNetRequestSync(payload, sender)
@@ -134,10 +183,10 @@ function TheClassicRaceSync:OnNetRequestSync(payload, sender)
     end
 
     -- extract requester's classIndex and hashes (payload is a table in new clients, plain number in old)
-    local requesterClassIndex, requesterGlobalHash, requesterClassHash, requesterFTLHash
+    local requesterClassIndex, requesterGlobalHash, requesterClassHash, requesterFTLHash, requesterPHHash
     if type(payload) == "table" then
-        requesterClassIndex, requesterGlobalHash, requesterClassHash, requesterFTLHash =
-                payload[1], payload[2], payload[3], payload[4]
+        requesterClassIndex, requesterGlobalHash, requesterClassHash, requesterFTLHash, requesterPHHash =
+                payload[1], payload[2], payload[3], payload[4], payload[5]
     else
         requesterClassIndex = payload
     end
@@ -147,10 +196,12 @@ function TheClassicRaceSync:OnNetRequestSync(payload, sender)
     local myClassHash = TheClassicRace.Leaderboard.ComputeHash(
             self.DB.factionrealm.leaderboard[self.classIndex] or {players = {}})
     local myFTLHash = computeFTLHash(self.DB, self.Config)
+    local myPHHash = computePHHash(self.DB, self.Config)
 
     -- skip offering if the requester already has identical data to us
     if requesterGlobalHash ~= nil and requesterGlobalHash == myGlobalHash
-            and (requesterFTLHash == nil or requesterFTLHash == myFTLHash) then
+            and (requesterFTLHash == nil or requesterFTLHash == myFTLHash)
+            and (requesterPHHash == nil or requesterPHHash == myPHHash) then
         local classSyncNeeded = requesterClassIndex == self.classIndex
                 and requesterClassHash ~= nil
                 and requesterClassHash ~= myClassHash
@@ -161,15 +212,17 @@ function TheClassicRaceSync:OnNetRequestSync(payload, sender)
     end
 
     self.Network:SendObject(self.Config.Network.Events.OfferSync,
-            { self.classIndex, self.lastSync, myGlobalHash, myClassHash, myFTLHash }, "WHISPER", sender)
+            { self.classIndex, self.lastSync, myGlobalHash, myClassHash, myFTLHash, myPHHash }, "WHISPER", sender)
 end
 
 function TheClassicRaceSync:OnNetOfferSync(offer, sender)
-    local classIndex, lastSync, globalHash, classHash, ftlHash = offer[1], offer[2], offer[3], offer[4], offer[5]
+    local classIndex, lastSync, globalHash, classHash, ftlHash, phHash =
+            offer[1], offer[2], offer[3], offer[4], offer[5], offer[6]
     TheClassicRace:DebugPrint("OnNetOfferSync(" .. sender .. ")")
     -- add anyone who offers to sync with us
     table.insert(self.offers, {name = sender, classIndex = classIndex, lastSync = lastSync,
-                               globalHash = globalHash, classHash = classHash, ftlHash = ftlHash})
+                               globalHash = globalHash, classHash = classHash, ftlHash = ftlHash,
+                               phHash = phHash})
     self:AddBuddy(sender)
 end
 
@@ -247,13 +300,17 @@ function TheClassicRaceSync:DoSync()
     local myClassHash = sameClass and TheClassicRace.Leaderboard.ComputeHash(
             self.DB.factionrealm.leaderboard[self.classIndex] or {players = {}})
     local myFTLHash = computeFTLHash(self.DB, self.Config)
+    local myPHHash = computePHHash(self.DB, self.Config)
 
     local globalMatch = self.syncPartner.globalHash ~= nil and self.syncPartner.globalHash == myGlobalHash
     local classMatch = not sameClass
             or (self.syncPartner.classHash ~= nil and self.syncPartner.classHash == myClassHash)
     local ftlMatch = self.syncPartner.ftlHash ~= nil and self.syncPartner.ftlHash == myFTLHash
+    -- player history is pull-only: a nil offer hash means an old client that can't
+    -- provide it, so treat that as matching rather than waiting on it
+    local phMatch = self.syncPartner.phHash == nil or self.syncPartner.phHash == myPHHash
 
-    if globalMatch and classMatch and ftlMatch then
+    if globalMatch and classMatch and ftlMatch and phMatch then
         TheClassicRace:DebugPrint("Already in sync with " .. self.syncPartner.name)
         self:SetReady()
         return
@@ -261,7 +318,7 @@ function TheClassicRaceSync:DoSync()
 
     -- include our hashes so the partner can also skip sending back data we already agree on
     self.Network:SendObject(self.Config.Network.Events.StartSync,
-            {self.classIndex, myGlobalHash, myClassHash, myFTLHash}, "WHISPER", self.syncPartner.name)
+            {self.classIndex, myGlobalHash, myClassHash, myFTLHash, myPHHash}, "WHISPER", self.syncPartner.name)
 
     -- check if we need to retry syncing after a short timeout
     local _self = self
@@ -294,7 +351,7 @@ function TheClassicRaceSync:OnNetStartSync(payload, sender)
     TheClassicRace:DebugPrint("OnNetStartSync(" .. sender .. ")")
     self.lastSync = self.Core:Now()
 
-    local requesterClassIndex, requesterGlobalHash, requesterClassHash, requesterFTLHash
+    local requesterClassIndex, requesterGlobalHash, requesterClassHash, requesterFTLHash, requesterPHHash
     if type(payload) == "table" then
         requesterClassIndex = payload[1]
 
@@ -316,11 +373,19 @@ function TheClassicRaceSync:OnNetStartSync(payload, sender)
             if guildFTLHash == nil or guildFTLHash ~= computeFTLHash(self.DB, self.Config) then
                 self:SyncFTL(sender)
             end
+            -- payload[4] is the requester's history hash, only present on their
+            -- once-per-login pull; never send history to clients that didn't ask
+            local guildPHHash = payload[4]
+            if guildPHHash ~= nil and guildPHHash ~= computePHHash(self.DB, self.Config) then
+                self:SyncPlayerHistory(sender)
+            end
             return
         end
 
-        -- zone sync: payload[2] is globalHash, payload[3] is classHash, payload[4] is ftlHash
-        requesterGlobalHash, requesterClassHash, requesterFTLHash = payload[2], payload[3], payload[4]
+        -- zone sync: payload[2] is globalHash, payload[3] is classHash, payload[4] is ftlHash,
+        -- payload[5] is the history hash
+        requesterGlobalHash, requesterClassHash, requesterFTLHash, requesterPHHash =
+                payload[2], payload[3], payload[4], payload[5]
     else
         requesterClassIndex = payload
     end
@@ -342,6 +407,12 @@ function TheClassicRaceSync:OnNetStartSync(payload, sender)
     local myFTLHash = computeFTLHash(self.DB, self.Config)
     if requesterFTLHash == nil or requesterFTLHash ~= myFTLHash then
         self:SyncFTL(sender)
+    end
+
+    -- player history is pull-only and potentially large: only send it when the
+    -- requester explicitly announced a differing hash (old clients never do)
+    if requesterPHHash ~= nil and requesterPHHash ~= computePHHash(self.DB, self.Config) then
+        self:SyncPlayerHistory(sender)
     end
 end
 
@@ -373,17 +444,21 @@ end
 
 -- Announce our presence to the guild and open a window for offers.
 -- Used both on login (called from InitSync) and by the periodic ticker.
-function TheClassicRaceSync:SendGuildSync()
+-- withPlayerHistory: true only for the login call — player history is potentially
+-- large, so it's pulled once per login and never re-negotiated by the ticker.
+function TheClassicRaceSync:SendGuildSync(withPlayerHistory)
     if not IsInGuild() then return end
     if not self.DB.profile.options.networking then return end
     if self.DB.factionrealm.finished then return end
 
     self.guildOffers = {}
+    self.guildPHWanted = withPlayerHistory or false
 
     local fullHash = computeFullHash(self.DB, self.Config)
     local ftlHash = computeFTLHash(self.DB, self.Config)
+    local phHash = withPlayerHistory and computePHHash(self.DB, self.Config) or nil
     self.Network:SendObject(self.Config.Network.Events.GuildSync,
-            {self.classIndex, fullHash, self.Core:LoginTime(), ftlHash}, "GUILD")
+            {self.classIndex, fullHash, self.Core:LoginTime(), ftlHash, phHash}, "GUILD")
 
     local _self = self
     C_Timer.After(self.Config.GuildSyncWait + 1, function()
@@ -397,13 +472,15 @@ function TheClassicRaceSync:OnNetGuildSync(payload, sender)
     if not self.DB.profile.options.networking then return end
     if not self.isReady then return end
 
-    local requesterFullHash, requesterFTLHash = payload[2], payload[4]
+    local requesterFullHash, requesterFTLHash, requesterPHHash = payload[2], payload[4], payload[5]
 
     local myFullHash = computeFullHash(self.DB, self.Config)
     local myFTLHash = computeFTLHash(self.DB, self.Config)
-    -- older clients don't announce an FTL hash; treat that as matching
+    -- older clients don't announce an FTL hash; treat that as matching.
+    -- the history hash is only present on a login announce (once-per-login pull)
     local ftlDiffers = requesterFTLHash ~= nil and requesterFTLHash ~= myFTLHash
-    if myFullHash == requesterFullHash and not ftlDiffers then return end
+    local phDiffers = requesterPHHash ~= nil and requesterPHHash ~= computePHHash(self.DB, self.Config)
+    if myFullHash == requesterFullHash and not ftlDiffers and not phDiffers then return end
 
     local delay = math.random(0, self.Config.GuildSyncWait)
     local _self = self
@@ -413,7 +490,7 @@ function TheClassicRaceSync:OnNetGuildSync(payload, sender)
                 _self.DB.factionrealm.leaderboard[_self.classIndex] or {players = {}})
         _self.Network:SendObject(_self.Config.Network.Events.GuildOffer,
                 {_self.classIndex, _self.lastSync, myFullHash, myGlobalHash, myClassHash, _self.Core:LoginTime(),
-                 computeFTLHash(_self.DB, _self.Config)},
+                 computeFTLHash(_self.DB, _self.Config), computePHHash(_self.DB, _self.Config)},
                 "WHISPER", sender)
     end)
 end
@@ -421,13 +498,13 @@ end
 -- Collect guild offers during the open window.
 function TheClassicRaceSync:OnNetGuildOffer(offer, sender)
     if self.guildOffers == nil then return end
-    local classIndex, lastSync, fullHash, globalHash, classHash, loginTime, ftlHash =
-            offer[1], offer[2], offer[3], offer[4], offer[5], offer[6], offer[7]
+    local classIndex, lastSync, fullHash, globalHash, classHash, loginTime, ftlHash, phHash =
+            offer[1], offer[2], offer[3], offer[4], offer[5], offer[6], offer[7], offer[8]
     TheClassicRace:DebugPrint("GuildOffer from " .. sender)
     table.insert(self.guildOffers, {
         name = sender, classIndex = classIndex, lastSync = lastSync,
         fullHash = fullHash, globalHash = globalHash, classHash = classHash, loginTime = loginTime,
-        ftlHash = ftlHash,
+        ftlHash = ftlHash, phHash = phHash,
     })
 end
 
@@ -614,6 +691,40 @@ function TheClassicRaceSync:OnNetFTLSync(payload, sender)
     self:SetReady()
 end
 
+-- Whispers the leaderboard-scoped playerHistory subset to the target player, in
+-- chunks of PlayerHistoryChunkSize players spaced PlayerHistoryChunkDelay seconds
+-- apart, so a large transfer stays friendly to the addon channel throttle.
+-- Only called for the target's once-per-login pull.
+function TheClassicRaceSync:SyncPlayerHistory(syncTo)
+    local names = relevantHistoryNames(self.DB, self.Config)
+    local chunks = TheClassicRace.Serializer.SerializePlayerHistoryChunks(
+            self.DB.factionrealm.playerHistory or {}, names, self.Config.PlayerHistoryChunkSize)
+
+    TheClassicRace:DebugPrint("SyncPlayerHistory(" .. syncTo .. "): "
+            .. #names .. " players in " .. #chunks .. " chunk(s)")
+
+    local _self = self
+    for i, chunk in ipairs(chunks) do
+        C_Timer.After((i - 1) * self.Config.PlayerHistoryChunkDelay, function()
+            _self.Network:SendObject(_self.Config.Network.Events.PlayerHistorySync, chunk, "WHISPER", syncTo)
+        end)
+    end
+end
+
+-- Received a playerHistory chunk — deserialize and forward to tracker for merging.
+-- Chunks are independently parseable, so each is merged as it arrives.
+function TheClassicRaceSync:OnNetPHSync(payload, sender)
+    if not self.DB.profile.options.networking then return end
+    TheClassicRace:DebugPrint("OnNetPHSync(" .. sender .. ")")
+
+    local batch = TheClassicRace.Serializer.DeserializePlayerHistoryBatch(payload or "")
+    self.EventBus:PublishEvent(self.Config.Events.PHSyncResult, batch)
+
+    -- a history payload also completes our initial sync: when only history differed
+    -- from our partner this is the only payload we'll receive
+    self:SetReady()
+end
+
 -- Called when the party roster changes. Debounced to avoid firing multiple times
 -- in quick succession. Sends BPING to GROUP so all members can exchange hashes
 -- and push any missing leaderboards.
@@ -677,11 +788,13 @@ function TheClassicRaceSync:DoGuildSync()
 
     TheClassicRace:DebugPrint("DoGuildSync with " .. best.name)
 
-    -- sanity check: if full hashes (and FTL, when the partner announced one) match
-    -- now, nothing to do
+    -- sanity check: if full hashes (and FTL/history, when negotiated) match now,
+    -- nothing to do
     local myFTLHash = computeFTLHash(self.DB, self.Config)
+    local myPHHash = self.guildPHWanted and computePHHash(self.DB, self.Config) or nil
     local ftlDiffers = best.ftlHash ~= nil and best.ftlHash ~= myFTLHash
-    if best.fullHash == computeFullHash(self.DB, self.Config) and not ftlDiffers then
+    local phDiffers = myPHHash ~= nil and best.phHash ~= nil and best.phHash ~= myPHHash
+    if best.fullHash == computeFullHash(self.DB, self.Config) and not ftlDiffers and not phDiffers then
         TheClassicRace:DebugPrint("Already in sync with guild partner " .. best.name)
         return
     end
@@ -693,7 +806,8 @@ function TheClassicRaceSync:DoGuildSync()
         myPerClassHashes[classIndex + 1] = lb and TheClassicRace.Leaderboard.ComputeHash(lb) or 0
     end
 
+    -- the history hash is only included on the once-per-login pull
     self.Network:SendObject(self.Config.Network.Events.StartSync,
-            {self.classIndex, myPerClassHashes, myFTLHash}, "WHISPER", best.name)
+            {self.classIndex, myPerClassHashes, myFTLHash, myPHHash}, "WHISPER", best.name)
 end
 

--- a/src/core/tracker.lua
+++ b/src/core/tracker.lua
@@ -49,6 +49,7 @@ function TheClassicRaceTracker.new(Config, Core, DB, EventBus, Network)
     EventBus:RegisterCallback(self.Config.Events.SlashWhoResult, self, self.OnSlashWhoResult)
     EventBus:RegisterCallback(self.Config.Events.SyncResult, self, self.OnSyncResult)
     EventBus:RegisterCallback(self.Config.Events.FTLSyncResult, self, self.OnFTLSyncResult)
+    EventBus:RegisterCallback(self.Config.Events.PHSyncResult, self, self.OnPHSyncResult)
     EventBus:RegisterCallback(self.Config.Events.ScanFinished, self, self.OnScanFinished)
 
     return self
@@ -86,6 +87,34 @@ function TheClassicRaceTracker:NormalizeDB()
                     record.dingedAt = math.floor(record.dingedAt)
                 end
             end
+        end
+    end
+
+    self:PrunePlayerHistory()
+end
+
+-- playerHistory records every character a scan ever saw and would grow unbounded
+-- (thousands of players on a busy realm). Only leaderboard members are relevant for
+-- the per-character breakdown and for syncing, so on login everyone else is dropped;
+-- our own history is always kept.
+function TheClassicRaceTracker:PrunePlayerHistory()
+    local playerHistory = self.DB.factionrealm.playerHistory
+    if playerHistory == nil then return end
+
+    local keep = {}
+    for classIndex = 0, #self.Config.Classes do
+        local lb = self.DB.factionrealm.leaderboard[classIndex]
+        if lb then
+            for _, player in ipairs(lb.players) do
+                keep[player.name] = true
+            end
+        end
+    end
+    keep[self.Core:Me()] = true
+
+    for name, _ in pairs(playerHistory) do
+        if not keep[name] then
+            playerHistory[name] = nil
         end
     end
 end
@@ -538,6 +567,37 @@ function TheClassicRaceTracker:UpdatePioneers(playerInfo)
     if classIndex ~= nil and classIndex ~= 0 then
         if db.firstToLevel[classIndex] == nil then db.firstToLevel[classIndex] = {} end
         mergeFTLRecord(db.firstToLevel[classIndex], level, name, classIndex, dingedAt)
+    end
+end
+
+-- Merges a received playerHistory chunk, keeping the earliest dingedAt per
+-- (player, level) and filling in a missing classIndex — deterministic and
+-- monotonic, so repeated exchanges converge instead of ping-ponging.
+-- batch = {[name] = {classIndex = ci, levels = {[level] = dingedAt}}}
+function TheClassicRaceTracker:OnPHSyncResult(batch)
+    local playerHistory = self.DB.factionrealm.playerHistory
+
+    for name, remote in pairs(batch) do
+        if type(remote) == "table" and type(remote.levels) == "table" then
+            if playerHistory[name] == nil then
+                playerHistory[name] = {classIndex = remote.classIndex, levels = {}}
+            end
+            local hist = playerHistory[name]
+
+            if (hist.classIndex == nil or hist.classIndex == 0)
+                    and remote.classIndex ~= nil and remote.classIndex ~= 0 then
+                hist.classIndex = remote.classIndex
+            end
+
+            for level, dingedAt in pairs(remote.levels) do
+                if type(level) == "number" and level >= 2 and level <= 99
+                        and type(dingedAt) == "number" then
+                    if hist.levels[level] == nil or dingedAt < hist.levels[level] then
+                        hist.levels[level] = math.floor(dingedAt)
+                    end
+                end
+            end
+        end
     end
 end
 

--- a/src/core/tracker.lua
+++ b/src/core/tracker.lua
@@ -93,10 +93,18 @@ function TheClassicRaceTracker:NormalizeDB()
     self:PrunePlayerHistory()
 end
 
+-- A leaderboard is final when it's full and its lowest member has reached max
+-- level: from then on, players absent from it can no longer enter the race for it.
+local function isLeaderboardFinal(lb, config)
+    return lb ~= nil and #lb.players >= config.MaxLeaderboardSize and lb.minLevel >= config.MaxLevel
+end
+
 -- playerHistory records every character a scan ever saw and would grow unbounded
--- (thousands of players on a busy realm). Only leaderboard members are relevant for
--- the per-character breakdown and for syncing, so on login everyone else is dropped;
--- our own history is always kept.
+-- (thousands of players on a busy realm). While the race is live everyone is kept —
+-- a player who temporarily drops off a leaderboard may re-enter it and would lose
+-- their history otherwise. Once the leaderboard a player competes on is final
+-- (full at max level), or the race is finished, non-members are dropped.
+-- Our own history is always kept.
 function TheClassicRaceTracker:PrunePlayerHistory()
     local playerHistory = self.DB.factionrealm.playerHistory
     if playerHistory == nil then return end
@@ -112,9 +120,24 @@ function TheClassicRaceTracker:PrunePlayerHistory()
     end
     keep[self.Core:Me()] = true
 
-    for name, _ in pairs(playerHistory) do
+    local raceFinished = self.DB.factionrealm.finished
+    local globalFinal = isLeaderboardFinal(self.DB.factionrealm.leaderboard[0], self.Config)
+
+    for name, hist in pairs(playerHistory) do
         if not keep[name] then
-            playerHistory[name] = nil
+            -- players with a known class compete on their class leaderboard;
+            -- unknown-class players are gated on the global leaderboard instead
+            local classIndex = hist ~= nil and hist.classIndex or nil
+            local boardFinal
+            if classIndex ~= nil and classIndex >= 1 and classIndex <= #self.Config.Classes then
+                boardFinal = isLeaderboardFinal(self.DB.factionrealm.leaderboard[classIndex], self.Config)
+            else
+                boardFinal = globalFinal
+            end
+
+            if raceFinished or boardFinal then
+                playerHistory[name] = nil
+            end
         end
     end
 end

--- a/src/defaultdb.lua
+++ b/src/defaultdb.lua
@@ -38,6 +38,7 @@ local TheClassicRaceDefaultDB = {
         -- raceStartedAt: earliest dingedAt ever seen; fallback reference when realmOpenedAt is nil
         raceStartedAt = nil,
         -- playerHistory[name] = {classIndex, levels = {[level] = dingedAt}}
+        -- pruned on login to leaderboard members (+ ourselves); synced once per login
         playerHistory = {},
         -- firstToLevel[classFilter][level] = {name, classIndex, dingedAt}
         -- classFilter 0 = overall, 1-12 = per class (see Config.ClassIndexes)

--- a/src/defaultdb.lua
+++ b/src/defaultdb.lua
@@ -38,7 +38,8 @@ local TheClassicRaceDefaultDB = {
         -- raceStartedAt: earliest dingedAt ever seen; fallback reference when realmOpenedAt is nil
         raceStartedAt = nil,
         -- playerHistory[name] = {classIndex, levels = {[level] = dingedAt}}
-        -- pruned on login to leaderboard members (+ ourselves); synced once per login
+        -- synced once per login (leaderboard players only); non-members are pruned on
+        -- login once the leaderboard they compete on is final (full at max level)
         playerHistory = {},
         -- firstToLevel[classFilter][level] = {name, classIndex, dingedAt}
         -- classFilter 0 = overall, 1-12 = per class (see Config.ClassIndexes)

--- a/tests/serializer.lua
+++ b/tests/serializer.lua
@@ -168,6 +168,87 @@ describe("Serializer", function()
         end)
     end)
 
+    describe("PlayerHistoryChunks", function()
+        local SerPHChunks = TheClassicRace.Serializer.SerializePlayerHistoryChunks
+        local DeserPHBatch = TheClassicRace.Serializer.DeserializePlayerHistoryBatch
+
+        it("empty history serializes to no chunks", function()
+            assert.same({}, SerPHChunks({}, {}, 20))
+            assert.same({}, DeserPHBatch(""))
+        end)
+
+        it("round-trips player history", function()
+            local t = 1000000000
+            local playerHistory = {
+                Alice = {classIndex = 3, levels = {[15] = t + 100, [16] = t + 200}},
+                Bob = {classIndex = 1, levels = {[10] = t}},
+            }
+
+            local chunks = SerPHChunks(playerHistory, {"Alice", "Bob"}, 20)
+            assert.equals(1, #chunks)
+
+            local result = DeserPHBatch(chunks[1])
+            assert.same(playerHistory, result)
+        end)
+
+        it("splits into chunks of at most chunkSize players, each independently parseable", function()
+            local t = 1000000000
+            local playerHistory = {
+                Alice = {classIndex = 3, levels = {[15] = t + 100}},
+                Bob = {classIndex = 1, levels = {[10] = t}},
+                Carol = {classIndex = 5, levels = {[20] = t + 500}},
+            }
+
+            local chunks = SerPHChunks(playerHistory, {"Alice", "Bob", "Carol"}, 2)
+            assert.equals(2, #chunks)
+
+            -- merging all chunks yields the full data set
+            local merged = {}
+            for _, chunk in ipairs(chunks) do
+                for name, hist in pairs(DeserPHBatch(chunk)) do
+                    merged[name] = hist
+                end
+            end
+            assert.same(playerHistory, merged)
+        end)
+
+        it("skips levels that don't fit the wire format and players without valid levels", function()
+            local t = 1000000000
+            local playerHistory = {
+                Alice = {classIndex = 3, levels = {[1] = t, [15] = t + 100, [100] = t}},
+                Fresh = {classIndex = 1, levels = {[1] = t}},
+            }
+
+            local chunks = SerPHChunks(playerHistory, {"Alice", "Fresh"}, 20)
+            assert.equals(1, #chunks)
+
+            local result = DeserPHBatch(chunks[1])
+            assert.same({Alice = {classIndex = 3, levels = {[15] = t + 100}}}, result)
+        end)
+
+        it("round-trips names containing a dash", function()
+            local t = 1000000000
+            local playerHistory = {
+                ["Nub-Ville"] = {classIndex = 2, levels = {[12] = t}},
+            }
+
+            local chunks = SerPHChunks(playerHistory, {"Nub-Ville"}, 20)
+            local result = DeserPHBatch(chunks[1])
+            assert.same(playerHistory, result)
+        end)
+
+        it("floors fractional timestamps", function()
+            local t = 1000000000
+            local playerHistory = {
+                Alice = {classIndex = 3, levels = {[15] = t + 100.9}},
+            }
+
+            local chunks = SerPHChunks(playerHistory, {"Alice"}, 20)
+            local result = DeserPHBatch(chunks[1])
+            assert.equals(t + 100, result["Alice"].levels[15])
+        end)
+    end)
+
     describe("PlayerInfoBatch", function()
         it("serializes and deserializes", function()
             local nub1 = {name = "Nubone", level = 5, dingedAt = time + 10, classIndex = 11}

--- a/tests/sync.lua
+++ b/tests/sync.lua
@@ -20,7 +20,7 @@ describe("Sync", function()
     local AdvanceClock
 
     -- shorthands for the hashes of our (empty) DB
-    local myGlobalHash, myClassHash, myFTLHash, myFullHash
+    local myGlobalHash, myClassHash, myFTLHash, myFullHash, myPHHash
 
     before_each(function()
         -- easier to only test channel
@@ -47,6 +47,7 @@ describe("Sync", function()
         myClassHash = TheClassicRace.Leaderboard.ComputeHash(db.factionrealm.leaderboard[11])
         myFTLHash = TheClassicRace.Sync.ComputeFTLHash(db, TheClassicRace.Config)
         myFullHash = TheClassicRace.Sync.ComputeFullHash(db, TheClassicRace.Config)
+        myPHHash = TheClassicRace.Sync.ComputePHHash(db, TheClassicRace.Config)
     end)
 
     after_each(function()
@@ -60,7 +61,7 @@ describe("Sync", function()
         sync:InitSync()
 
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.RequestSync,
-                {11, myGlobalHash, myClassHash, myFTLHash}, "YELL")
+                {11, myGlobalHash, myClassHash, myFTLHash, myPHHash}, "YELL")
         assert.spy(networkSpy).called_at_most(1)
         networkSpy:clear()
 
@@ -78,9 +79,9 @@ describe("Sync", function()
         sync:InitSync()
 
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.RequestSync,
-                {11, myGlobalHash, myClassHash, myFTLHash}, "YELL")
+                {11, myGlobalHash, myClassHash, myFTLHash, myPHHash}, "YELL")
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.GuildSync,
-                {11, myFullHash, core:LoginTime(), myFTLHash}, "GUILD")
+                {11, myFullHash, core:LoginTime(), myFTLHash, myPHHash}, "GUILD")
         assert.spy(networkSpy).called_at_most(2)
     end)
 
@@ -97,7 +98,7 @@ describe("Sync", function()
 
         -- no hashes known -> sends global + class leaderboards and FTL data
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync,
-                {11, myGlobalHash, myClassHash, myFTLHash}, "WHISPER", "Dude")
+                {11, myGlobalHash, myClassHash, myFTLHash, myPHHash}, "WHISPER", "Dude")
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload, "", "WHISPER", "Dude")
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.FTLSync, {""}, "WHISPER", "Dude")
         assert.spy(networkSpy).called_at_most(4)
@@ -133,7 +134,7 @@ describe("Sync", function()
         AdvanceClock(TheClassicRace.Config.RequestSyncWait)
 
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync,
-                {11, myGlobalHash, myClassHash, myFTLHash}, "WHISPER", "Dude")
+                {11, myGlobalHash, myClassHash, myFTLHash, myPHHash}, "WHISPER", "Dude")
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.FTLSync, {""}, "WHISPER", "Dude")
         assert.spy(networkSpy).called_at_most(2)
     end)
@@ -258,7 +259,7 @@ describe("Sync", function()
         eventbus:PublishEvent(NetEvents.RequestSync, 11, "Dude")
 
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.OfferSync,
-                {11, nil, myGlobalHash, myClassHash, myFTLHash}, "WHISPER", "Dude")
+                {11, nil, myGlobalHash, myClassHash, myFTLHash, myPHHash}, "WHISPER", "Dude")
         assert.spy(networkSpy).called_at_most(1)
         networkSpy:clear()
 
@@ -292,7 +293,7 @@ describe("Sync", function()
                 {11, myGlobalHash, myClassHash + 1, myFTLHash}, "Dude")
 
         assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.OfferSync,
-                {11, nil, myGlobalHash, myClassHash, myFTLHash}, "WHISPER", "Dude")
+                {11, nil, myGlobalHash, myClassHash, myFTLHash, myPHHash}, "WHISPER", "Dude")
         assert.spy(networkSpy).called_at_most(1)
     end)
 
@@ -378,7 +379,7 @@ describe("Sync", function()
             AdvanceClock(TheClassicRace.Config.GuildSyncWait)
 
             assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.GuildOffer,
-                    {11, nil, myFullHash, myGlobalHash, myClassHash, core:LoginTime(), myFTLHash},
+                    {11, nil, myFullHash, myGlobalHash, myClassHash, core:LoginTime(), myFTLHash, myPHHash},
                     "WHISPER", "Dude")
             assert.spy(networkSpy).called_at_most(1)
         end)
@@ -456,6 +457,144 @@ describe("Sync", function()
             eventbus:PublishEvent(NetEvents.StartSync, {11, perClassHashes}, "Dude")
             assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.FTLSync,
                     {""}, "WHISPER", "Dude")
+            assert.spy(networkSpy).called_at_most(1)
+        end)
+    end)
+
+    describe("player history sync", function()
+        local seedHistory
+
+        before_each(function()
+            -- seed a leaderboard member with history so the sync subset is non-empty
+            seedHistory = function()
+                db.factionrealm.leaderboard[0].players = {
+                    {name = "Racer", level = 30, dingedAt = time, classIndex = 4},
+                }
+                db.factionrealm.playerHistory = {
+                    Racer = {classIndex = 4, levels = {[29] = time - 50, [30] = time}},
+                }
+            end
+        end)
+
+        it("pushes player history when the requester announces a differing hash", function()
+            local networkSpy = spy.on(network, "SendObject")
+            seedHistory()
+
+            local globalHash = TheClassicRace.Leaderboard.ComputeHash(db.factionrealm.leaderboard[0])
+            local phHash = TheClassicRace.Sync.ComputePHHash(db, TheClassicRace.Config)
+
+            eventbus:PublishEvent(NetEvents.StartSync,
+                    {11, globalHash, myClassHash, myFTLHash, phHash + 1}, "Dude")
+
+            -- chunks are sent via timers
+            AdvanceClock(TheClassicRace.Config.PlayerHistoryChunkDelay)
+
+            local expectedChunk = TheClassicRace.Serializer.SerializePlayerHistoryChunks(
+                    db.factionrealm.playerHistory, {"Racer"}, TheClassicRace.Config.PlayerHistoryChunkSize)[1]
+            assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.PlayerHistorySync,
+                    expectedChunk, "WHISPER", "Dude")
+            assert.spy(networkSpy).called_at_most(1)
+        end)
+
+        it("doesn't push player history when the requester's hash matches", function()
+            local networkSpy = spy.on(network, "SendObject")
+            seedHistory()
+
+            local globalHash = TheClassicRace.Leaderboard.ComputeHash(db.factionrealm.leaderboard[0])
+            local phHash = TheClassicRace.Sync.ComputePHHash(db, TheClassicRace.Config)
+
+            eventbus:PublishEvent(NetEvents.StartSync,
+                    {11, globalHash, myClassHash, myFTLHash, phHash}, "Dude")
+            AdvanceClock(TheClassicRace.Config.PlayerHistoryChunkDelay)
+
+            assert.spy(networkSpy).called_at_most(0)
+        end)
+
+        it("never pushes player history to old clients that sent no hash", function()
+            local networkSpy = spy.on(network, "SendObject")
+            seedHistory()
+
+            -- old client StartSync: differing global hash but no history hash
+            eventbus:PublishEvent(NetEvents.StartSync,
+                    {11, myGlobalHash + 1, myClassHash, myFTLHash}, "Dude")
+            AdvanceClock(TheClassicRace.Config.PlayerHistoryChunkDelay)
+
+            assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.SyncPayload,
+                    match.is_string(), "WHISPER", "Dude")
+            assert.spy(networkSpy).called_at_most(1)
+        end)
+
+        it("marks ready when receiving a player history payload", function()
+            assert.equals(false, sync.isReady)
+
+            eventbus:PublishEvent(NetEvents.PlayerHistorySync, "", "Dude")
+
+            assert.equals(true, sync.isReady)
+        end)
+
+        it("forwards received player history chunks to the tracker", function()
+            local eventBusSpy = spy.on(eventbus, "PublishEvent")
+            seedHistory()
+
+            local chunk = TheClassicRace.Serializer.SerializePlayerHistoryChunks(
+                    db.factionrealm.playerHistory, {"Racer"}, TheClassicRace.Config.PlayerHistoryChunkSize)[1]
+            sync:OnNetPHSync(chunk, "Dude")
+
+            assert.spy(eventBusSpy).was_called_with(match.is_ref(eventbus), Events.PHSyncResult,
+                    match.is_same({
+                        Racer = {classIndex = 4, levels = {[29] = time - 50, [30] = time}},
+                    }))
+        end)
+
+        it("guild ticker sync doesn't negotiate player history", function()
+            local networkSpy = spy.on(network, "SendObject")
+            _G.SetIsInGuild(true)
+
+            -- ticker-style call, no withPlayerHistory flag
+            sync:SendGuildSync()
+
+            assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.GuildSync,
+                    {11, myFullHash, core:LoginTime(), myFTLHash}, "GUILD")
+            assert.spy(networkSpy).called_at_most(1)
+            networkSpy:clear()
+
+            -- even a partner whose history hash differs doesn't trigger a history pull
+            eventbus:PublishEvent(NetEvents.GuildOffer,
+                    {11, nil, myFullHash + 1, myGlobalHash, myClassHash, time - 100, myFTLHash, myPHHash + 1},
+                    "Dude")
+            AdvanceClock(TheClassicRace.Config.GuildSyncWait + 1)
+
+            local perClassHashes = {}
+            for classIndex = 0, #TheClassicRace.Config.Classes do
+                perClassHashes[classIndex + 1] = TheClassicRace.Leaderboard.ComputeHash(
+                        db.factionrealm.leaderboard[classIndex])
+            end
+            assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync,
+                    {11, perClassHashes, myFTLHash}, "WHISPER", "Dude")
+            assert.spy(networkSpy).called_at_most(1)
+        end)
+
+        it("login guild sync pulls player history when it differs", function()
+            local networkSpy = spy.on(network, "SendObject")
+            _G.SetIsInGuild(true)
+
+            -- login-style call: negotiate player history too
+            sync:SendGuildSync(true)
+            networkSpy:clear()
+
+            -- partner matches everything except player history
+            eventbus:PublishEvent(NetEvents.GuildOffer,
+                    {11, nil, myFullHash, myGlobalHash, myClassHash, time - 100, myFTLHash, myPHHash + 1},
+                    "Dude")
+            AdvanceClock(TheClassicRace.Config.GuildSyncWait + 1)
+
+            local perClassHashes = {}
+            for classIndex = 0, #TheClassicRace.Config.Classes do
+                perClassHashes[classIndex + 1] = TheClassicRace.Leaderboard.ComputeHash(
+                        db.factionrealm.leaderboard[classIndex])
+            end
+            assert.spy(networkSpy).was_called_with(match.is_ref(network), NetEvents.StartSync,
+                    {11, perClassHashes, myFTLHash, myPHHash}, "WHISPER", "Dude")
             assert.spy(networkSpy).called_at_most(1)
         end)
     end)

--- a/tests/tracker.lua
+++ b/tests/tracker.lua
@@ -470,23 +470,87 @@ describe("Tracker", function()
             assert.equals(time, hist.levels[10])
         end)
 
-        it("PrunePlayerHistory drops players that aren't on any leaderboard", function()
+        it("PrunePlayerHistory keeps everyone while the race is still live", function()
             db.factionrealm.leaderboard[0].players = {
                 {name = "OnBoard", level = 30, dingedAt = time, classIndex = DRUIDIDX},
             }
             db.factionrealm.playerHistory = {
                 OnBoard = {classIndex = DRUIDIDX, levels = {[30] = time}},
                 Rando = {classIndex = WARRIORIDX, levels = {[10] = time}},
-                -- ourselves ("Nub"), never pruned even when not on a leaderboard
-                Nub = {classIndex = DRUIDIDX, levels = {[5] = time}},
             }
 
             -- constructing a tracker runs NormalizeDB, which prunes
             TheClassicRace.Tracker(config, core, db, TheClassicRace.EventBus(), network)
 
+            -- no leaderboard is final yet: Rando may still enter the race
+            assert.is_table(db.factionrealm.playerHistory["OnBoard"])
+            assert.is_table(db.factionrealm.playerHistory["Rando"])
+        end)
+
+        it("PrunePlayerHistory drops non-members once their class leaderboard is final", function()
+            local players = {}
+            for i = 1, config.MaxLeaderboardSize do
+                players[i] = {name = "Warrior" .. i, level = config.MaxLevel, dingedAt = time + i,
+                              classIndex = WARRIORIDX}
+            end
+            db.factionrealm.leaderboard[WARRIORIDX].players = players
+            db.factionrealm.leaderboard[WARRIORIDX].minLevel = config.MaxLevel
+
+            db.factionrealm.playerHistory = {
+                Warrior1 = {classIndex = WARRIORIDX, levels = {[config.MaxLevel] = time}},
+                Rando = {classIndex = WARRIORIDX, levels = {[10] = time}},
+                Druid = {classIndex = DRUIDIDX, levels = {[10] = time}},
+                Unknown = {classIndex = 0, levels = {[10] = time}},
+                -- ourselves, same class as the final board but never pruned
+                Nub = {classIndex = WARRIORIDX, levels = {[5] = time}},
+            }
+
+            TheClassicRace.Tracker(config, core, db, TheClassicRace.EventBus(), network)
+
+            -- warriors not on the final warrior board are out of that race
+            assert.is_nil(db.factionrealm.playerHistory["Rando"])
+            -- board members, other classes (their boards are still live), unknown-class
+            -- players (global board still live) and ourselves are all kept
+            assert.is_table(db.factionrealm.playerHistory["Warrior1"])
+            assert.is_table(db.factionrealm.playerHistory["Druid"])
+            assert.is_table(db.factionrealm.playerHistory["Unknown"])
+            assert.is_table(db.factionrealm.playerHistory["Nub"])
+        end)
+
+        it("PrunePlayerHistory drops unknown-class non-members once the global leaderboard is final", function()
+            local players = {}
+            for i = 1, config.MaxLeaderboardSize do
+                players[i] = {name = "Racer" .. i, level = config.MaxLevel, dingedAt = time + i,
+                              classIndex = DRUIDIDX}
+            end
+            db.factionrealm.leaderboard[0].players = players
+            db.factionrealm.leaderboard[0].minLevel = config.MaxLevel
+
+            db.factionrealm.playerHistory = {
+                Unknown = {classIndex = 0, levels = {[10] = time}},
+            }
+
+            TheClassicRace.Tracker(config, core, db, TheClassicRace.EventBus(), network)
+
+            assert.is_nil(db.factionrealm.playerHistory["Unknown"])
+        end)
+
+        it("PrunePlayerHistory drops all non-members when the race is finished", function()
+            db.factionrealm.finished = true
+            db.factionrealm.leaderboard[0].players = {
+                {name = "OnBoard", level = 30, dingedAt = time, classIndex = DRUIDIDX},
+            }
+            db.factionrealm.playerHistory = {
+                OnBoard = {classIndex = DRUIDIDX, levels = {[30] = time}},
+                Rando = {classIndex = WARRIORIDX, levels = {[10] = time}},
+                Nub = {classIndex = DRUIDIDX, levels = {[5] = time}},
+            }
+
+            TheClassicRace.Tracker(config, core, db, TheClassicRace.EventBus(), network)
+
+            assert.is_nil(db.factionrealm.playerHistory["Rando"])
             assert.is_table(db.factionrealm.playerHistory["OnBoard"])
             assert.is_table(db.factionrealm.playerHistory["Nub"])
-            assert.is_nil(db.factionrealm.playerHistory["Rando"])
         end)
 
         it("OnFTLSyncResult ignores records that don't fit the wire format", function()

--- a/tests/tracker.lua
+++ b/tests/tracker.lua
@@ -424,6 +424,71 @@ describe("Tracker", function()
             assert.equals(DRUIDIDX, db.factionrealm.firstToLevel[0][10].classIndex)
         end)
 
+        it("OnPHSyncResult merges new players into playerHistory", function()
+            tracker:OnPHSyncResult({
+                Racer = {classIndex = WARRIORIDX, levels = {[10] = time - 100, [11] = time}},
+            })
+
+            local hist = db.factionrealm.playerHistory["Racer"]
+            assert.equals(WARRIORIDX, hist.classIndex)
+            assert.equals(time - 100, hist.levels[10])
+            assert.equals(time, hist.levels[11])
+        end)
+
+        it("OnPHSyncResult keeps the earliest dingedAt per level", function()
+            tracker:ProcessPlayerInfo(playerInfo("Racer", 10, DRUIDIDX, time - 100))
+
+            tracker:OnPHSyncResult({
+                Racer = {classIndex = DRUIDIDX, levels = {[10] = time, [11] = time + 50}},
+            })
+
+            local hist = db.factionrealm.playerHistory["Racer"]
+            -- local level-10 record was earlier, remote level-11 record is new
+            assert.equals(time - 100, hist.levels[10])
+            assert.equals(time + 50, hist.levels[11])
+        end)
+
+        it("OnPHSyncResult fills in a missing classIndex", function()
+            tracker:ProcessPlayerInfo({name = "Racer", level = 10, classIndex = 0, dingedAt = time})
+            assert.equals(0, db.factionrealm.playerHistory["Racer"].classIndex)
+
+            tracker:OnPHSyncResult({
+                Racer = {classIndex = DRUIDIDX, levels = {[10] = time}},
+            })
+
+            assert.equals(DRUIDIDX, db.factionrealm.playerHistory["Racer"].classIndex)
+        end)
+
+        it("OnPHSyncResult ignores levels that don't fit the wire format", function()
+            tracker:OnPHSyncResult({
+                Racer = {classIndex = DRUIDIDX, levels = {[1] = time, [100] = time, [10] = time}},
+            })
+
+            local hist = db.factionrealm.playerHistory["Racer"]
+            assert.is_nil(hist.levels[1])
+            assert.is_nil(hist.levels[100])
+            assert.equals(time, hist.levels[10])
+        end)
+
+        it("PrunePlayerHistory drops players that aren't on any leaderboard", function()
+            db.factionrealm.leaderboard[0].players = {
+                {name = "OnBoard", level = 30, dingedAt = time, classIndex = DRUIDIDX},
+            }
+            db.factionrealm.playerHistory = {
+                OnBoard = {classIndex = DRUIDIDX, levels = {[30] = time}},
+                Rando = {classIndex = WARRIORIDX, levels = {[10] = time}},
+                -- ourselves ("Nub"), never pruned even when not on a leaderboard
+                Nub = {classIndex = DRUIDIDX, levels = {[5] = time}},
+            }
+
+            -- constructing a tracker runs NormalizeDB, which prunes
+            TheClassicRace.Tracker(config, core, db, TheClassicRace.EventBus(), network)
+
+            assert.is_table(db.factionrealm.playerHistory["OnBoard"])
+            assert.is_table(db.factionrealm.playerHistory["Nub"])
+            assert.is_nil(db.factionrealm.playerHistory["Rando"])
+        end)
+
         it("OnFTLSyncResult ignores records that don't fit the wire format", function()
             tracker:OnFTLSyncResult({
                 [0] = {


### PR DESCRIPTION
## What

Backfills per-character level timestamps (`playerHistory`) for players who were offline, so the upcoming per-character breakdown UI has data from the whole realm rather than only what each client observed itself.

## Why the narrow design

`playerHistory` records every character a /who scan ever saw — unbounded, unlike the 50-player leaderboards. Estimates for a busy realm over a race:

| | |
|---|---|
| Characters observed | 5,000–20,000 |
| Total (level, timestamp) entries | 50k–200k |
| Serialized | **0.5–2 MB** — unshippable over addon channels (~1 KB/s background) |

Two cuts make it practical:

1. **Scope: leaderboard players only** (≤650 names, realistically 200–400 → ~20–85 KB compressed).
2. **Frequency: once per login, pull-only.** Two online clients scanning simultaneously always drift, so any periodic hash comparison (1-min beacons, 10-min buddy pings, 5-min guild ticker) would mismatch every cycle and re-transfer ~50 KB each time. While online, the existing real-time `PINFOB` ding broadcasts keep everyone current — the only real gap is time spent offline, so history is negotiated exactly once, during the login handshake, toward the player who just logged in.

Local DB growth is bounded separately: on login, history of players not on any leaderboard is pruned — but only once the leaderboard they compete on is **final** (full with everyone at max level), or the race is finished. While the race is live everyone is kept, so a contender who temporarily drops off a board doesn't lose their history. Own history is always kept.

## How

- History hash (djb2 over the sorted leaderboard-scoped subset) appended to `REQSYNC`/`OFFERSYNC`/`STARTSYNC`; guild handshake carries it only when login-triggered (`SendGuildSync(withPlayerHistory)`), never from the 5-minute ticker.
- On mismatch the partner whispers `PHSYNC` chunks: 20 players per message, 2 s apart, each chunk independently parseable so partial delivery still merges.
- Merge keeps earliest `dingedAt` per (player, level) + fills unknown classIndex — deterministic and monotonic, no #16-style mismatch loops.
- Old clients never announce the hash and are never sent payloads they can't parse.

## Testing

21 new tests (wire format round-trip/chunking/guards, pull-only handshake incl. old-client compat and guild ticker exclusion, tracker merge + race-aware prune). Full suite: **187 passing, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)